### PR TITLE
Update GUI_BMPfile.c

### DIFF
--- a/2.7inch_e-paper_code/bcm2835/obj/GUI_BMPfile.c
+++ b/2.7inch_e-paper_code/bcm2835/obj/GUI_BMPfile.c
@@ -84,7 +84,7 @@ UBYTE GUI_ReadBmp(const char *path, UWORD Xstart, UWORD Ystart)
     BMPRGBQUAD bmprgbquad[bmprgbquadsize];        //palette
     
     for(i = 0; i < bmprgbquadsize; i++){
-        fread(&bmprgbquad[i * 4], sizeof(BMPRGBQUAD), 1, fp);
+        fread(&bmprgbquad[i], sizeof(BMPRGBQUAD), 1, fp);
     }
     if(bmprgbquad[0].rgbBlue == 0xff && bmprgbquad[0].rgbGreen == 0xff && bmprgbquad[0].rgbRed == 0xff){
         Bcolor = BLACK;


### PR DESCRIPTION
This is present in all GUI_BMPFiles.  It causes a segfault.  You don't need to multiply the index by 4, C takes care of this for you already.  The previous code will write beyond the bounds of the array.