### PR TITLE
Fix implicit casting

### DIFF
--- a/RaspberryPi&JetsonNano/python/lib/waveshare_epd/epd1in54_V2.py
+++ b/RaspberryPi&JetsonNano/python/lib/waveshare_epd/epd1in54_V2.py
@@ -181,7 +181,7 @@ class EPD:
         
         self.send_command(0x26)
         for j in range(0, self.height):
-            for i in range(0, self.width / 8):
+            for i in range(0, int(self.width / 8)):
                 self.send_data(image[i + j * int(self.width / 8)])
                 
         self.TurnOnDisplayPart()


### PR DESCRIPTION
Fix implicit casting in 1.54 screen driver that prevent example to run.

Original example output : 

```
DEBUG:root:Horizontal
Traceback (most recent call last):
  File "epd_1in54_V2_test.py", line 66, in <module>
    epd.displayPartBaseImage(epd.getbuffer(time_image))
  File "/home/pi/e-Paper/RaspberryPi&JetsonNano/python/lib/waveshare_epd/epd1in54_V2.py", line 184, in displayPartBaseImage
    for i in range(0, self.width / 8):
TypeError: 'float' object cannot be interpreted as an integer
```