### PR TITLE
Fixed Arduino epd7in5_V2 Displaypart and DsiplayFrame methods

### DIFF
--- a/Arduino/epd7in5_V2/epd7in5_V2.cpp
+++ b/Arduino/epd7in5_V2/epd7in5_V2.cpp
@@ -121,8 +121,8 @@ void Epd::DisplayFrame(const unsigned char* frame_buffer) {
     
     SendCommand(0x13);
     for (unsigned long j = 0; j < height; j++) {
-        for (unsigned long i = 0; i < width; i++) {
-            SendData(~frame_buffer[i + j * width]);
+        for (unsigned long i = 0; i < width/8; i++) {
+            SendData(~frame_buffer[i + j * width/8]);
         }
     }
     SendCommand(0x12);

--- a/Arduino/epd7in5_V2/epd7in5_V2.h
+++ b/Arduino/epd7in5_V2/epd7in5_V2.h
@@ -46,7 +46,7 @@ public:
     void SendData(unsigned char data);
     void Sleep(void);
     void Clear(void);
-    void Epd::Displaypart(const unsigned char* pbuffer, unsigned long Start_X, unsigned long Start_Y,unsigned long END_X,unsigned long END_Y);
+    void Displaypart(const unsigned char* pbuffer, unsigned long Start_X, unsigned long Start_Y,unsigned long END_X,unsigned long END_Y);
  
 private:
     unsigned int reset_pin;


### PR DESCRIPTION
Fixed minor error in Displaypart method declaration. Fixed width calculation in DisplayFrame method for Arduino epd7in5_V2.