### PR TITLE
Fix Arduino/epd4in2(bc) x_end calculation

### DIFF
--- a/Arduino/epd4in2/epd4in2.cpp
+++ b/Arduino/epd4in2/epd4in2.cpp
@@ -159,7 +159,7 @@ void Epd::SetPartialWindow(const unsigned char* buffer_black, int x, int y, int 
     SendCommand(PARTIAL_WINDOW);
     SendData(x >> 8);
     SendData(x & 0xf8);     // x should be the multiple of 8, the last 3 bit will always be ignored
-    SendData(((x & 0xf8) + w  - 1) >> 8);
+    SendData(((x & 0xfff8) + w  - 1) >> 8);
     SendData(((x & 0xf8) + w  - 1) | 0x07);
     SendData(y >> 8);        
     SendData(y & 0xff);

--- a/Arduino/epd4in2bc/epd4in2b.cpp
+++ b/Arduino/epd4in2bc/epd4in2b.cpp
@@ -103,7 +103,7 @@ void Epd::SetPartialWindow(const unsigned char* buffer_black, const unsigned cha
     SendCommand(PARTIAL_WINDOW);
     SendData(x >> 8);
     SendData(x & 0xf8);     // x should be the multiple of 8, the last 3 bit will always be ignored
-    SendData(((x & 0xf8) + w  - 1) >> 8);
+    SendData(((x & 0xfff8) + w  - 1) >> 8);
     SendData(((x & 0xf8) + w  - 1) | 0x07);
     SendData(y >> 8);        
     SendData(y & 0xff);
@@ -136,7 +136,7 @@ void Epd::SetPartialWindowBlack(const unsigned char* buffer_black, int x, int y,
     SendCommand(PARTIAL_WINDOW);
     SendData(x >> 8);
     SendData(x & 0xf8);     // x should be the multiple of 8, the last 3 bit will always be ignored
-    SendData(((x & 0xf8) + w  - 1) >> 8);
+    SendData(((x & 0xfff8) + w  - 1) >> 8);
     SendData(((x & 0xf8) + w  - 1) | 0x07);
     SendData(y >> 8);        
     SendData(y & 0xff);
@@ -162,7 +162,7 @@ void Epd::SetPartialWindowRed(const unsigned char* buffer_red, int x, int y, int
     SendCommand(PARTIAL_WINDOW);
     SendData(x >> 8);
     SendData(x & 0xf8);     // x should be the multiple of 8, the last 3 bit will always be ignored
-    SendData(((x & 0xf8) + w  - 1) >> 8);
+    SendData(((x & 0xfff8) + w  - 1) >> 8);
     SendData(((x & 0xf8) + w  - 1) | 0x07);
     SendData(y >> 8);        
     SendData(y & 0xff);


### PR DESCRIPTION
The original implementation ignores higher bits when calculating the end of x in the SetPartialWindow functions, which causes problem when we have x larger than 256. 