### PR TITLE
Update epdconfig.py

### DIFF
--- a/RaspberryPi&JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/RaspberryPi&JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -46,8 +46,8 @@ class RaspberryPi:
 
         self.GPIO = RPi.GPIO
 
-        # SPI device, bus = 0, device = 0
-        self.SPI = spidev.SpiDev(0, 0)
+        # initialize SPI device
+        self.SPI = spidev.SpiDev()
 
     def digital_write(self, pin, value):
         self.GPIO.output(pin, value)
@@ -68,6 +68,7 @@ class RaspberryPi:
         self.GPIO.setup(self.DC_PIN, self.GPIO.OUT)
         self.GPIO.setup(self.CS_PIN, self.GPIO.OUT)
         self.GPIO.setup(self.BUSY_PIN, self.GPIO.IN)
+        self.SPI.open(0, 0) # open SPI at bus = 0, device = 0
         self.SPI.max_speed_hz = 4000000
         self.SPI.mode = 0b00
         return 0


### PR DESCRIPTION
with these changes you can sleep the device and resume communication to it at a later moment without an SPI error or restarting the python application