### PR TITLE
Fix Python cleanup and exit execution path.

### DIFF
--- a/RaspberryPi&JetsonNano/python/examples/epd_1in02_test.py
+++ b/RaspberryPi&JetsonNano/python/examples/epd_1in02_test.py
@@ -95,5 +95,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd1in54.epdconfig.module_exit()
+    epd1in02.epdconfig.module_exit()
     exit()

--- a/RaspberryPi&JetsonNano/python/examples/epd_1in54b_V2_test.py
+++ b/RaspberryPi&JetsonNano/python/examples/epd_1in54b_V2_test.py
@@ -76,5 +76,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd1in54b.epdconfig.module_exit()
+    epd1in54b_V2.epdconfig.module_exit()
     exit()

--- a/RaspberryPi&JetsonNano/python/examples/epd_7in5_V2_test.py
+++ b/RaspberryPi&JetsonNano/python/examples/epd_7in5_V2_test.py
@@ -86,5 +86,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd7in5.epdconfig.module_exit()
+    epd7in5_V2.epdconfig.module_exit()
     exit()

--- a/RaspberryPi&JetsonNano/python/examples/epd_7in5b_V2_test.py
+++ b/RaspberryPi&JetsonNano/python/examples/epd_7in5b_V2_test.py
@@ -93,5 +93,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd7in5.epdconfig.module_exit()
+    epd7in5bc_V2.epdconfig.module_exit()
     exit()

--- a/RaspberryPi&JetsonNano/python/examples/epd_7in5b_V3_test.py
+++ b/RaspberryPi&JetsonNano/python/examples/epd_7in5b_V3_test.py
@@ -93,5 +93,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd7in5.epdconfig.module_exit()
+    epd7in5b_V3.epdconfig.module_exit()
     exit()


### PR DESCRIPTION
This fix apparently seems to be very trivial but if the user terminates an
executing Python example program with `CTRL+C` and then leaves the
display at that state then power is still applied to the display as a result
of not executing the cleanup and exit path. This can damage the display
eventually.