### PR TITLE
add missing cast to int

### DIFF
--- a/RaspberryPi&JetsonNano/python/lib/waveshare_epd/epd1in54_V2.py
+++ b/RaspberryPi&JetsonNano/python/lib/waveshare_epd/epd1in54_V2.py
@@ -181,7 +181,7 @@ class EPD:
         
         self.send_command(0x26)
         for j in range(0, self.height):
-            for i in range(0, self.width / 8):
+            for i in range(0, int(self.width / 8)):
                 self.send_data(image[i + j * int(self.width / 8)])
                 
         self.TurnOnDisplayPart()


### PR DESCRIPTION
avoid `TypeError: 'float' object cannot be interpreted as an integer`

This cast was obviously forgotten.