### PR TITLE
Fix examples referencing wrong library in KeyboardInterrupt

### DIFF
--- a/RaspberryPi&JetsonNano/python/examples/epd_1in02_test.py
+++ b/RaspberryPi&JetsonNano/python/examples/epd_1in02_test.py
@@ -96,5 +96,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd1in54.epdconfig.module_exit()
+    epd1in02.epdconfig.module_exit()
     exit()

--- a/RaspberryPi&JetsonNano/python/examples/epd_1in54b_V2_test.py
+++ b/RaspberryPi&JetsonNano/python/examples/epd_1in54b_V2_test.py
@@ -77,5 +77,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd1in54b.epdconfig.module_exit()
+    epd1in54b_V2.epdconfig.module_exit()
     exit()

--- a/RaspberryPi&JetsonNano/python/examples/epd_7in5_V2_test.py
+++ b/RaspberryPi&JetsonNano/python/examples/epd_7in5_V2_test.py
@@ -87,5 +87,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd7in5.epdconfig.module_exit()
+    epd7in5_V2.epdconfig.module_exit()
     exit()

--- a/RaspberryPi&JetsonNano/python/examples/epd_7in5b_V2_test.py
+++ b/RaspberryPi&JetsonNano/python/examples/epd_7in5b_V2_test.py
@@ -94,5 +94,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd7in5.epdconfig.module_exit()
+    epd7in5bc_V2.epdconfig.module_exit()
     exit()


### PR DESCRIPTION
Some of the examples were calling a different driver than the one imported when stopped with Ctrl+C.