### PR TITLE
Use spi pins

### DIFF
--- a/Arduino/epd1in54/epdif.h
+++ b/Arduino/epd1in54/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd1in54_V2/epdif.h
+++ b/Arduino/epd1in54_V2/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd1in54b/epdif.h
+++ b/Arduino/epd1in54b/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd1in54b_V2/epdif.h
+++ b/Arduino/epd1in54b_V2/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd1in54c/epdif.h
+++ b/Arduino/epd1in54c/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd2in13/epdif.h
+++ b/Arduino/epd2in13/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd2in13_V2/epdif.h
+++ b/Arduino/epd2in13_V2/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd2in13b_V3/epdif.h
+++ b/Arduino/epd2in13b_V3/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd2in13bc/epdif.h
+++ b/Arduino/epd2in13bc/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd2in13d/epdif.h
+++ b/Arduino/epd2in13d/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd2in66/epdif.h
+++ b/Arduino/epd2in66/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd2in66b/epdif.h
+++ b/Arduino/epd2in66b/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd2in7/epdif.h
+++ b/Arduino/epd2in7/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd2in7b/epdif.h
+++ b/Arduino/epd2in7b/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd2in9/epdif.h
+++ b/Arduino/epd2in9/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd2in9_V2/epdif.h
+++ b/Arduino/epd2in9_V2/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd2in9b_V3/epdif.h
+++ b/Arduino/epd2in9b_V3/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd2in9bc/epdif.h
+++ b/Arduino/epd2in9bc/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd2in9d/epdif.h
+++ b/Arduino/epd2in9d/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd3in7/epdif.h
+++ b/Arduino/epd3in7/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd4in2/epdif.h
+++ b/Arduino/epd4in2/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd4in2b_V2/epdif.h
+++ b/Arduino/epd4in2b_V2/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd4in2bc/epdif.h
+++ b/Arduino/epd4in2bc/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd5in65f/epdif.h
+++ b/Arduino/epd5in65f/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd5in83/epdif.h
+++ b/Arduino/epd5in83/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd5in83_V2/epdif.h
+++ b/Arduino/epd5in83_V2/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd5in83b_V2/epdif.h
+++ b/Arduino/epd5in83b_V2/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd5in83bc/epdif.h
+++ b/Arduino/epd5in83bc/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd7in5/epdif.h
+++ b/Arduino/epd7in5/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd7in5_HD/epdif.h
+++ b/Arduino/epd7in5_HD/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd7in5_V2/epdif.h
+++ b/Arduino/epd7in5_V2/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd7in5b_HD/epdif.h
+++ b/Arduino/epd7in5b_HD/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd7in5b_V2/epdif.h
+++ b/Arduino/epd7in5b_V2/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {

--- a/Arduino/epd7in5bc/epdif.h
+++ b/Arduino/epd7in5bc/epdif.h
@@ -33,7 +33,7 @@
 // Pin definition
 #define RST_PIN         8
 #define DC_PIN          9
-#define CS_PIN          10
+#define CS_PIN          SS
 #define BUSY_PIN        7
 
 class EpdIf {


### PR DESCRIPTION
User the default ChipSelect pin as provided by Arduino also for other models than the Arduino Uno. E.g. for the Arduino Mega the SPI ChipSelect pin is 53.