### PR TITLE
Update epdif.cpp

### DIFF
--- a/Arduino/epd1in54_V2/epdif.cpp
+++ b/Arduino/epd1in54_V2/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };


### PR DESCRIPTION
Correct spelling of include file (SPI.h) for all OS (now only compile for Windows, which is not care about upper/lower case)