### PR TITLE
Significantly increase speed of displaying images (for 7in5 and 7in_HD)

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5.py
@@ -87,10 +87,10 @@ class EPD:
         self.send_data2([0x37, 0x00])
         
         self.send_command(0x00) # PANEL_SETTING
-        self.send_data([0xCF, 0x08])
+        self.send_data2([0xCF, 0x08])
         
         self.send_command(0x06) # BOOSTER_SOFT_START
-        self.send_data([0xc7, 0xcc, 0x28])
+        self.send_data2([0xc7, 0xcc, 0x28])
         
         self.send_command(0x04) # POWER_ON
         self.ReadBusy()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5.py
@@ -65,6 +65,12 @@ class EPD:
         epdconfig.spi_writebyte([data])
         epdconfig.digital_write(self.cs_pin, 1)
         
+    def send_data2(self, data):
+        epdconfig.digital_write(self.dc_pin, 1)
+        epdconfig.digital_write(self.cs_pin, 0)
+        epdconfig.spi_writebyte2(data)
+        epdconfig.digital_write(self.cs_pin, 1)
+        
     def ReadBusy(self):
         logging.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
@@ -78,17 +84,13 @@ class EPD:
         self.reset()
         
         self.send_command(0x01) # POWER_SETTING
-        self.send_data(0x37)
-        self.send_data(0x00)
+        self.send_data2([0x37, 0x00])
         
         self.send_command(0x00) # PANEL_SETTING
-        self.send_data(0xCF)
-        self.send_data(0x08)
+        self.send_data([0xCF, 0x08])
         
         self.send_command(0x06) # BOOSTER_SOFT_START
-        self.send_data(0xc7)
-        self.send_data(0xcc)
-        self.send_data(0x28)
+        self.send_data([0xc7, 0xcc, 0x28])
         
         self.send_command(0x04) # POWER_ON
         self.ReadBusy()
@@ -121,72 +123,50 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        logging.debug("1234")
-        buf = [0x00] * int(self.width * self.height / 4)
-        image_monocolor = image.convert('1')
-        imwidth, imheight = image_monocolor.size
-        pixels = image_monocolor.load()
-        logging.debug('imwidth = %d  imheight =  %d ',imwidth, imheight)
+        img = image
+        imwidth, imheight = img.size
+        halfwidth = int(self.width / 2)
+        buf = [0x33] * halfwidth * self.height
+        
         if(imwidth == self.width and imheight == self.height):
-            for y in range(imheight):
-                for x in range(imwidth):
-                    # Set the bits for the column of pixels at the current position.
-                    if pixels[x, y] < 64:           # black
-                        buf[int((x + y * self.width) / 4)] &= ~(0xC0 >> (x % 4 * 2))
-                    elif pixels[x, y] < 192:     # convert gray to red
-                        buf[int((x + y * self.width) / 4)] &= ~(0xC0 >> (x % 4 * 2))
-                        buf[int((x + y * self.width) / 4)] |= 0x40 >> (x % 4 * 2)
-                    else:                           # white
-                        buf[int((x + y * self.width) / 4)] |= 0xC0 >> (x % 4 * 2)
+            img = img.convert('1')
         elif(imwidth == self.height and imheight == self.width):
-            for y in range(imheight):
-                for x in range(imwidth):
-                    newx = y
-                    newy = self.height - x - 1                    
-                    if pixels[x, y] < 64:           # black
-                        buf[int((newx + newy*self.width) / 4)] &= ~(0xC0 >> (y % 4 * 2))
-                    elif pixels[x, y] < 192:     # convert gray to red
-                        buf[int((newx + newy*self.width) / 4)] &= ~(0xC0 >> (y % 4 * 2))
-                        buf[int((newx + newy*self.width) / 4)] |= 0x40 >> (y % 4 * 2)
-                    else:                           # white
-                        buf[int((newx + newy*self.width) / 4)] |= 0xC0 >> (y % 4 * 2)
-        return buf    
+            img = img.rotate(90, expand=True).convert('1')
+            imwidth, imheight = img.size
+        else:
+            logging.warning("Wrong image dimensions: must be " + str(self.width) + "x" + str(self.height))
+            # return a blank buffer
+            return buf
+        
+        pixels = img.load()
+
+        for y in range(imheight):
+            offset = y * halfwidth
+            for x in range(1, imwidth, 2):
+                i = offset + x // 2
+                if(pixels[x-1, y] > 191):
+                    if(pixels[x, y] > 191):
+                        buf[i] = 0x33
+                    else:
+                        buf[i] = 0x30
+                else:
+                    if(pixels[x, y] > 191):
+                        buf[i] = 0x03
+                    else:
+                        buf[i] = 0x00
+        return buf
         
     def display(self, image):
         self.send_command(0x10)
-        for i in range(0, int(self.width / 4 * self.height)):
-            temp1 = image[i]
-            j = 0
-            while (j < 4):
-                if ((temp1 & 0xC0) == 0xC0):
-                    temp2 = 0x03
-                elif ((temp1 & 0xC0) == 0x00):
-                    temp2 = 0x00
-                else:
-                    temp2 = 0x04
-                temp2 = (temp2 << 4) & 0xFF
-                temp1 = (temp1 << 2) & 0xFF
-                j += 1
-                if((temp1 & 0xC0) == 0xC0):
-                    temp2 |= 0x03
-                elif ((temp1 & 0xC0) == 0x00):
-                    temp2 |= 0x00
-                else:
-                    temp2 |= 0x04
-                temp1 = (temp1 << 2) & 0xFF
-                self.send_data(temp2)
-                j += 1
-                
+        self.send_data2(image)
         self.send_command(0x12)
         epdconfig.delay_ms(100)
         self.ReadBusy()
         
     def Clear(self):
+        buf = [0x33] * int(self.width * self.height / 2)
         self.send_command(0x10)
-        for i in range(0, int(self.width / 4 * self.height)):
-            for j in range(0, 4):
-                self.send_data(0x33)
-                
+        self.send_data2(buf)
         self.send_command(0x12)
         self.ReadBusy()
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_HD.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_HD.py
@@ -65,6 +65,12 @@ class EPD:
         epdconfig.spi_writebyte([data])
         epdconfig.digital_write(self.cs_pin, 1)
         
+    def send_data2(self, data):
+        epdconfig.digital_write(self.dc_pin, 1)
+        epdconfig.digital_write(self.cs_pin, 0)
+        epdconfig.spi_writebyte2(data)
+        epdconfig.digital_write(self.cs_pin, 1)
+        
     def ReadBusy(self):
         logging.debug("e-Paper busy")
         busy = epdconfig.digital_read(self.busy_pin)
@@ -90,31 +96,35 @@ class EPD:
         self.ReadBusy();
 
         self.send_command(0x0C);  # Soft start setting
-        self.send_data(0xAE);
-        self.send_data(0xC7);
-        self.send_data(0xC3);
-        self.send_data(0xC0);
-        self.send_data(0x40); 
+        self.send_data2([0xAE, 0xC7, 0xC3, 0xC0, 0x40])
+        #self.send_data(0xAE);
+        #self.send_data(0xC7);
+        #self.send_data(0xC3);
+        #self.send_data(0xC0);
+        #self.send_data(0x40); 
 
 
         self.send_command(0x01);  # Set MUX as 527
-        self.send_data(0xAF);
-        self.send_data(0x02);
-        self.send_data(0x01);#0x01
+        self.send_data2([0xAF, 0x02, 0x01])
+        #self.send_data(0xAF);
+        #self.send_data(0x02);
+        #self.send_data(0x01);#0x01
 
         self.send_command(0x11);  # Data entry mode      
         self.send_data(0x01);
 
         self.send_command(0x44); 
-        self.send_data(0x00); # RAM x address start at 0
-        self.send_data(0x00); 
-        self.send_data(0x6F); 
-        self.send_data(0x03); 
+        self.send_data2([0x00, 0x00, 0x6F, 0x03]) # RAM x address start at 0
+        #self.send_data(0x00); # RAM x address start at 0
+        #self.send_data(0x00); 
+        #self.send_data(0x6F); 
+        #self.send_data(0x03); 
         self.send_command(0x45); 
-        self.send_data(0xAF); 
-        self.send_data(0x02);
-        self.send_data(0x00); 
-        self.send_data(0x00);
+        self.send_data2([0xAF, 0x02, 0x00, 0x00])
+        #self.send_data(0xAF); 
+        #self.send_data(0x02);
+        #self.send_data(0x00); 
+        #self.send_data(0x00);
 
         self.send_command(0x3C); # VBD
         self.send_data(0x05); # LUT1, for white
@@ -129,46 +139,32 @@ class EPD:
         self.ReadBusy();
 
         self.send_command(0x4E); # set RAM x address count to 0;
-        self.send_data(0x00);
-        self.send_data(0x00);
+        self.send_data2([0x00, 0x00])
         self.send_command(0x4F); 
-        self.send_data(0x00);
-        self.send_data(0x00);
+        self.send_data2([0x00, 0x00])
         # EPD hardware init end
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
-        buf = [0xFF] * (int(self.width/8) * self.height)
-        image_monocolor = image.convert('1')
-        imwidth, imheight = image_monocolor.size
-        pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        img = image
+        imwidth, imheight = img.size
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
-            for y in range(imheight):
-                for x in range(imwidth):
-                    # Set the bits for the column of pixels at the current position.
-                    if pixels[x, y] == 0:
-                        buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
+            img = img.convert('1')
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
-            for y in range(imheight):
-                for x in range(imwidth):
-                    newx = y
-                    newy = self.height - x - 1
-                    if pixels[x, y] == 0:
-                        buf[int((newx + newy*self.width) / 8)] &= ~(0x80 >> (y % 8))
+            img = img.rotate(90, expand=True).convert('1')
+        else:
+            logging.warning("Wrong image dimensions: must be " + str(self.width) + "x" + str(self.height))
+            # return a blank buffer
+            return [0x00] * (int(self.width/8) * self.height)
+
+        buf = bytearray(img.tobytes('raw'))
         return buf
         
     def display(self, image):
         self.send_command(0x4F); 
-        self.send_data(0x00);
-        self.send_data(0x00);
+        self.send_data2([0x00, 0x00])
         self.send_command(0x24);
-        for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(image[i]);
-                
+        self.send_data2(image)
         self.send_command(0x22);
         self.send_data(0xF7);#Load LUT from MCU(0x32)
         self.send_command(0x20);
@@ -176,16 +172,14 @@ class EPD:
         self.ReadBusy();
         
     def Clear(self):
+        buf = [0xff] * int(self.width * self.height / 8)
         self.send_command(0x4F); 
-        self.send_data(0x00);
-        self.send_data(0x00);
+        self.send_data2([0x00, 0x00])
         self.send_command(0x24)
-        for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xff)
+        self.send_data2(buf)
             
         self.send_command(0x26)
-        for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xff)
+        self.send_data2(buf)
                 
         self.send_command(0x22);
         self.send_data(0xF7);#Load LUT from MCU(0x32)

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_HD.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_HD.py
@@ -97,34 +97,17 @@ class EPD:
 
         self.send_command(0x0C);  # Soft start setting
         self.send_data2([0xAE, 0xC7, 0xC3, 0xC0, 0x40])
-        #self.send_data(0xAE);
-        #self.send_data(0xC7);
-        #self.send_data(0xC3);
-        #self.send_data(0xC0);
-        #self.send_data(0x40); 
-
 
         self.send_command(0x01);  # Set MUX as 527
         self.send_data2([0xAF, 0x02, 0x01])
-        #self.send_data(0xAF);
-        #self.send_data(0x02);
-        #self.send_data(0x01);#0x01
 
         self.send_command(0x11);  # Data entry mode      
         self.send_data(0x01);
 
         self.send_command(0x44); 
         self.send_data2([0x00, 0x00, 0x6F, 0x03]) # RAM x address start at 0
-        #self.send_data(0x00); # RAM x address start at 0
-        #self.send_data(0x00); 
-        #self.send_data(0x6F); 
-        #self.send_data(0x03); 
         self.send_command(0x45); 
         self.send_data2([0xAF, 0x02, 0x00, 0x00])
-        #self.send_data(0xAF); 
-        #self.send_data(0x02);
-        #self.send_data(0x00); 
-        #self.send_data(0x00);
 
         self.send_command(0x3C); # VBD
         self.send_data(0x05); # LUT1, for white
@@ -155,7 +138,7 @@ class EPD:
         else:
             logging.warning("Wrong image dimensions: must be " + str(self.width) + "x" + str(self.height))
             # return a blank buffer
-            return [0x00] * (int(self.width/8) * self.height)
+            return [0xff] * int(self.width * self.height / 8)
 
         buf = bytearray(img.tobytes('raw'))
         return buf

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -61,6 +61,9 @@ class RaspberryPi:
     def spi_writebyte(self, data):
         self.SPI.writebytes(data)
 
+    def spi_writebyte2(self, data):
+        self.SPI.writebytes2(data)
+
     def module_init(self):
         self.GPIO.setmode(self.GPIO.BCM)
         self.GPIO.setwarnings(False)


### PR DESCRIPTION
Extention of PR #104 to 7in5 (V1) and 7in_HD.

Great boost of performance, especially notable with RPI Zero. Drawing time decrease from ~40 seconds to ~5 seconds.

- Data is sent to display as byte array instead of single byte-by-byte. Use the `SPI.writebytes2()` function.
- For 7in5 (V1) removed unnecessary package of 4 values in one byte and then repacking to 2 values in one byte.