### PR TITLE
Fix examples referencing wrong module in KeyboardInterrupt

### DIFF
--- a/RaspberryPi_JetsonNano/python/examples/epd_1in02_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_1in02_test.py
@@ -98,5 +98,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd1in54.epdconfig.module_exit()
+    epd1in02.epdconfig.module_exit()
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_1in54b_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_1in54b_V2_test.py
@@ -79,5 +79,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd1in54b.epdconfig.module_exit()
+    epd1in54b_V2.epdconfig.module_exit()
     exit()


### PR DESCRIPTION
Some of the examples are still calling a different module than the one imported when stopped with Ctrl+C.