### PR TITLE
Consolidate duplicate functions

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in02.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in02.py
@@ -37,10 +37,7 @@ EPD_HEIGHT      = 128
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
     
@@ -86,152 +83,131 @@ class EPD:
     0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  
     0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  
     ]
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)         # module reset
-        epdconfig.delay_ms(2)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
 
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
-        
     def ReadBusy(self):
         logging.debug("e-Paper busy")
-        self.send_command(0x71)
+        epdconfig.send_command(0x71)
         busy = epdconfig.digital_read(self.busy_pin)
         busy =not(busy & 0x01)
         while(busy):
-            self.send_command(0x71)
+            epdconfig.send_command(0x71)
             busy = epdconfig.digital_read(self.busy_pin)
             busy =not(busy & 0x01)
         epdconfig.delay_ms(800)
         logging.debug("e-Paper busy release")        
 
     def TurnOnDisplay(self):
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(10)
         self.ReadBusy()
 
     def SetFulltReg(self):
-        self.send_command(0x23)
+        epdconfig.send_command(0x23)
         for count in range(0, 42):
-            self.send_data(self.lut_w1[count]) 
+            epdconfig.send_data(self.lut_w1[count]) 
         
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for count in range(0, 42):
-            self.send_data(self.lut_b1[count])     
+            epdconfig.send_data(self.lut_b1[count])     
 
     def SetPartReg(self):
-        self.send_command(0x23)
+        epdconfig.send_command(0x23)
         for count in range(0, 42):
-            self.send_data(self.lut_w[count]) 
+            epdconfig.send_data(self.lut_w[count]) 
         
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for count in range(0, 42):
-            self.send_data(self.lut_b[count])     
+            epdconfig.send_data(self.lut_b[count])     
 
     def Init(self):
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 2, 200)
         
-        self.send_command(0xD2)			
-        self.send_data(0x3F)
+        epdconfig.send_command(0xD2)			
+        epdconfig.send_data(0x3F)
 
-        self.send_command(0x00)  			
-        self.send_data (0x6F)  #from outside
+        epdconfig.send_command(0x00)  			
+        epdconfig.send_data (0x6F)  #from outside
 
-        self.send_command(0x01)  #power setting
-        self.send_data (0x03)	    
-        self.send_data (0x00)
-        self.send_data (0x2b)		
-        self.send_data (0x2b) 
+        epdconfig.send_command(0x01)  #power setting
+        epdconfig.send_data (0x03)	    
+        epdconfig.send_data (0x00)
+        epdconfig.send_data (0x2b)		
+        epdconfig.send_data (0x2b) 
 
-        self.send_command(0x06)  #Configuring the charge pump
-        self.send_data(0x3f)
+        epdconfig.send_command(0x06)  #Configuring the charge pump
+        epdconfig.send_data(0x3f)
 
-        self.send_command(0x2A)  #Setting XON and the options of LUT
-        self.send_data(0x00) 
-        self.send_data(0x00) 
+        epdconfig.send_command(0x2A)  #Setting XON and the options of LUT
+        epdconfig.send_data(0x00) 
+        epdconfig.send_data(0x00) 
 
-        self.send_command(0x30)  #Set the clock frequency
-        self.send_data(0x17) #50Hz
+        epdconfig.send_command(0x30)  #Set the clock frequency
+        epdconfig.send_data(0x17) #50Hz
 
-        self.send_command(0x50)  #Set VCOM and data output interval
-        self.send_data(0x57)			
+        epdconfig.send_command(0x50)  #Set VCOM and data output interval
+        epdconfig.send_data(0x57)			
 
-        self.send_command(0x60)  #Set The non-overlapping period of Gate and Source.
-        self.send_data(0x22)
+        epdconfig.send_command(0x60)  #Set The non-overlapping period of Gate and Source.
+        epdconfig.send_data(0x22)
 
-        self.send_command(0x61)  #resolution setting
-        self.send_data (0x50)    #source 128 	 
-        self.send_data (0x80)       
+        epdconfig.send_command(0x61)  #resolution setting
+        epdconfig.send_data (0x50)    #source 128 	 
+        epdconfig.send_data (0x80)       
 
-        self.send_command(0x82)  #sets VCOM_DC value
-        self.send_data(0x12)  #-1v
+        epdconfig.send_command(0x82)  #sets VCOM_DC value
+        epdconfig.send_data(0x12)  #-1v
 
-        self.send_command(0xe3)#Set POWER SAVING
-        self.send_data(0x33)
+        epdconfig.send_command(0xe3)#Set POWER SAVING
+        epdconfig.send_data(0x33)
         self.SetFulltReg()	
-        self.send_command(0x04)     		#power on
+        epdconfig.send_command(0x04)     		#power on
         self.ReadBusy()
         # EPD hardware init end
         return 0
     
     def Partial_Init(self):
-        self.reset()
+        epdconfig.reset(200, 2, 200)
         
-        self.send_command(0xD2)
-        self.send_data(0x3F)
+        epdconfig.send_command(0xD2)
+        epdconfig.send_data(0x3F)
 
-        self.send_command(0x00)
-        self.send_data (0x6F)  #from outside
+        epdconfig.send_command(0x00)
+        epdconfig.send_data (0x6F)  #from outside
 
-        self.send_command(0x01)  #power setting
-        self.send_data (0x03)
-        self.send_data (0x00)
-        self.send_data (0x2b)
-        self.send_data (0x2b)
+        epdconfig.send_command(0x01)  #power setting
+        epdconfig.send_data (0x03)
+        epdconfig.send_data (0x00)
+        epdconfig.send_data (0x2b)
+        epdconfig.send_data (0x2b)
 
-        self.send_command(0x06)  #Configuring the charge pump
-        self.send_data(0x3f)
+        epdconfig.send_command(0x06)  #Configuring the charge pump
+        epdconfig.send_data(0x3f)
 
-        self.send_command(0x2A)  #Setting XON and the options of LUT
-        self.send_data(0x00)
-        self.send_data(0x00)
+        epdconfig.send_command(0x2A)  #Setting XON and the options of LUT
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00)
 
-        self.send_command(0x30)  #Set the clock frequency
-        self.send_data(0x17)
+        epdconfig.send_command(0x30)  #Set the clock frequency
+        epdconfig.send_data(0x17)
 
-        self.send_command(0x50)  #Set VCOM and data output interval
-        self.send_data(0xf2)
+        epdconfig.send_command(0x50)  #Set VCOM and data output interval
+        epdconfig.send_data(0xf2)
 
-        self.send_command(0x60)  #Set The non-overlapping period of Gate and Source.
-        self.send_data(0x22)
+        epdconfig.send_command(0x60)  #Set The non-overlapping period of Gate and Source.
+        epdconfig.send_data(0x22)
 
-        self.send_command(0x82)  #Set VCOM_DC value
-        self.send_data(0x12)#-1v
+        epdconfig.send_command(0x82)  #Set VCOM_DC value
+        epdconfig.send_data(0x12)#-1v
 
-        self.send_command(0xe3)#Set POWER SAVING
-        self.send_data(0x33)
+        epdconfig.send_command(0xe3)#Set POWER SAVING
+        epdconfig.send_data(0x33)
 
         self.SetPartReg()	
 
-        self.send_command(0x04)#Set POWER SAVING	
+        epdconfig.send_command(0x04)#Set POWER SAVING	
         self.ReadBusy()
         # EPD hardware init end
         return 0
@@ -267,15 +243,15 @@ class EPD:
         else:
             Width = self.width / 8 + 1
             
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for j in range(0, self.height):
             for i in range(0, int(Width)):
-                self.send_data(0xff)  
+                epdconfig.send_data(0xff)  
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for j in range(0, self.height):
             for i in range(0, int(Width)):
-                self.send_data(image[i + j * int(Width)])  
+                epdconfig.send_data(image[i + j * int(Width)])  
         self.TurnOnDisplay()
         
     def Clear(self):
@@ -287,28 +263,28 @@ class EPD:
             
         Height = self.height
         
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for j in range(0, Height):
             for i in range(0, int(Width)):
-                self.send_data(0x00)  
+                epdconfig.send_data(0x00)  
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for j in range(0, Height):
             for i in range(0, int(Width)):
-                self.send_data(0xff)  
+                epdconfig.send_data(0xff)  
         self.TurnOnDisplay()
 
     def DisplayPartial(self, old_Image, Image):
 
         # Set partial Windows */
-        self.send_command(0x91)		#This command makes the display enter partial mode
-        self.send_command(0x90)		#resolution setting
-        self.send_data(0)           #x-start
-        self.send_data(79)       #x-end
+        epdconfig.send_command(0x91)		#This command makes the display enter partial mode
+        epdconfig.send_command(0x90)		#resolution setting
+        epdconfig.send_data(0)           #x-start
+        epdconfig.send_data(79)       #x-end
 
-        self.send_data(0)
-        self.send_data(127)  #y-end
-        self.send_data(0x00)
+        epdconfig.send_data(0)
+        epdconfig.send_data(127)  #y-end
+        epdconfig.send_data(0x00)
        
         # Width = (self.width % 8 == 0)? (self.width / 8 ): (self.width / 8 + 1)
         if(self.width % 8 == 0):
@@ -318,26 +294,26 @@ class EPD:
             
         Height = self.height
         # send data
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for j in range(0, Height):
             for i in range(0, int(Width)):
-                self.send_data(old_Image[i + j * int(Width)])
+                epdconfig.send_data(old_Image[i + j * int(Width)])
 
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for j in range(0, Height):
             for i in range(0, int(Width)):
-                self.send_data(Image[i + j * int(Width)])
+                epdconfig.send_data(Image[i + j * int(Width)])
 
         # Set partial refresh
         self.TurnOnDisplay()
 
     def Sleep(self):
-        self.send_command(0x50)
-        self.send_data(0xf7)
-        self.send_command(0x02)
+        epdconfig.send_command(0x50)
+        epdconfig.send_data(0xf7)
+        epdconfig.send_command(0x02)
         self.ReadBusy()
-        self.send_command(0x07)
-        self.send_data(0xA5)
+        epdconfig.send_command(0x07)
+        epdconfig.send_data(0xA5)
         epdconfig.delay_ms(200)
 
         epdconfig.delay_ms(2000)

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54.py
@@ -88,10 +88,7 @@ EPD_HEIGHT      = 200
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
 
@@ -107,28 +104,7 @@ class EPD:
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
         0x00, 0x00, 0x00, 0x00, 0x13, 0x14, 0x44, 0x12, 
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-    ]
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)         # module reset
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
+    ] 
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -137,66 +113,66 @@ class EPD:
         logging.debug("e-Paper busy release")
 
     def TurnOnDisplay(self):
-        self.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
-        self.send_data(0xC4)
-        self.send_command(0x20) # MASTER_ACTIVATION
-        self.send_command(0xFF) # TERMINATE_FRAME_READ_WRITE
+        epdconfig.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
+        epdconfig.send_data(0xC4)
+        epdconfig.send_command(0x20) # MASTER_ACTIVATION
+        epdconfig.send_command(0xFF) # TERMINATE_FRAME_READ_WRITE
         
         self.ReadBusy()
 
     def SetWindow(self, x_start, y_start, x_end, y_end):
-        self.send_command(0x44) # SET_RAM_X_ADDRESS_START_END_POSITION
+        epdconfig.send_command(0x44) # SET_RAM_X_ADDRESS_START_END_POSITION
         # x point must be the multiple of 8 or the last 3 bits will be ignored
-        self.send_data((x_start >> 3) & 0xFF)
-        self.send_data((x_end >> 3) & 0xFF)
-        self.send_command(0x45) # SET_RAM_Y_ADDRESS_START_END_POSITION
-        self.send_data(y_start & 0xFF)
-        self.send_data((y_start >> 8) & 0xFF)
-        self.send_data(y_end & 0xFF)
-        self.send_data((y_end >> 8) & 0xFF)
+        epdconfig.send_data((x_start >> 3) & 0xFF)
+        epdconfig.send_data((x_end >> 3) & 0xFF)
+        epdconfig.send_command(0x45) # SET_RAM_Y_ADDRESS_START_END_POSITION
+        epdconfig.send_data(y_start & 0xFF)
+        epdconfig.send_data((y_start >> 8) & 0xFF)
+        epdconfig.send_data(y_end & 0xFF)
+        epdconfig.send_data((y_end >> 8) & 0xFF)
 
     def SetCursor(self, x, y):
-        self.send_command(0x4E) # SET_RAM_X_ADDRESS_COUNTER
+        epdconfig.send_command(0x4E) # SET_RAM_X_ADDRESS_COUNTER
         # x point must be the multiple of 8 or the last 3 bits will be ignored
-        self.send_data((x >> 3) & 0xFF)
+        epdconfig.send_data((x >> 3) & 0xFF)
         
-        self.send_command(0x4F) # SET_RAM_Y_ADDRESS_COUNTER
-        self.send_data(y & 0xFF)
-        self.send_data((y >> 8) & 0xFF)
+        epdconfig.send_command(0x4F) # SET_RAM_Y_ADDRESS_COUNTER
+        epdconfig.send_data(y & 0xFF)
+        epdconfig.send_data((y >> 8) & 0xFF)
         # self.ReadBusy()
         
     def init(self, lut):
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
-        self.send_command(0x01) # DRIVER_OUTPUT_CONTROL
-        self.send_data((EPD_HEIGHT - 1) & 0xFF)
-        self.send_data(((EPD_HEIGHT - 1) >> 8) & 0xFF)
-        self.send_data(0x00) # GD = 0 SM = 0 TB = 0
+        epdconfig.send_command(0x01) # DRIVER_OUTPUT_CONTROL
+        epdconfig.send_data((EPD_HEIGHT - 1) & 0xFF)
+        epdconfig.send_data(((EPD_HEIGHT - 1) >> 8) & 0xFF)
+        epdconfig.send_data(0x00) # GD = 0 SM = 0 TB = 0
         
-        self.send_command(0x0C) # BOOSTER_SOFT_START_CONTROL
-        self.send_data(0xD7)
-        self.send_data(0xD6)
-        self.send_data(0x9D)
+        epdconfig.send_command(0x0C) # BOOSTER_SOFT_START_CONTROL
+        epdconfig.send_data(0xD7)
+        epdconfig.send_data(0xD6)
+        epdconfig.send_data(0x9D)
         
-        self.send_command(0x2C) # WRITE_VCOM_REGISTER
-        self.send_data(0xA8) # VCOM 7C
+        epdconfig.send_command(0x2C) # WRITE_VCOM_REGISTER
+        epdconfig.send_data(0xA8) # VCOM 7C
         
-        self.send_command(0x3A) # SET_DUMMY_LINE_PERIOD
-        self.send_data(0x1A) # 4 dummy lines per gate
+        epdconfig.send_command(0x3A) # SET_DUMMY_LINE_PERIOD
+        epdconfig.send_data(0x1A) # 4 dummy lines per gate
         
-        self.send_command(0x3B) # SET_GATE_TIME
-        self.send_data(0x08) # 2us per line
+        epdconfig.send_command(0x3B) # SET_GATE_TIME
+        epdconfig.send_data(0x08) # 2us per line
         
-        self.send_command(0x11) # DATA_ENTRY_MODE_SETTING
-        self.send_data(0x03) # X increment Y increment
+        epdconfig.send_command(0x11) # DATA_ENTRY_MODE_SETTING
+        epdconfig.send_data(0x03) # X increment Y increment
         
         # set the look-up table register
-        self.send_command(0x32)
+        epdconfig.send_command(0x32)
         for i in range(0, len(lut)):
-            self.send_data(lut[i])
+            epdconfig.send_data(lut[i])
         # EPD hardware init end
         return 0
 
@@ -229,9 +205,9 @@ class EPD:
         self.SetWindow(0, 0, self.width, self.height)
         for j in range(0, self.height):
             self.SetCursor(0, j)
-            self.send_command(0x24)
+            epdconfig.send_command(0x24)
             for i in range(0, int(self.width / 8)):
-                self.send_data(image[i + j * int(self.width / 8)])   
+                epdconfig.send_data(image[i + j * int(self.width / 8)])   
         self.TurnOnDisplay()
         
     def Clear(self, color):
@@ -242,15 +218,15 @@ class EPD:
         # epdconfig.digital_write(self.cs_pin, 0)
         for j in range(0, self.height):
             self.SetCursor(0, j)
-            self.send_command(0x24)
+            epdconfig.send_command(0x24)
             for i in range(0, int(self.width / 8)):
-                self.send_data(color)
+                epdconfig.send_data(color)
         # epdconfig.digital_write(self.cs_pin, 1)
         self.TurnOnDisplay()
 
     def sleep(self):
-        self.send_command(0x10) # DEEP_SLEEP_MODE
-        self.send_data(0x01)
+        epdconfig.send_command(0x10) # DEEP_SLEEP_MODE
+        epdconfig.send_data(0x01)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54_V2.py
@@ -36,34 +36,10 @@ EPD_HEIGHT      = 200
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
 
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
-        
     def ReadBusy(self):
         logging.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 1):
@@ -71,15 +47,15 @@ class EPD:
         logging.debug("e-Paper busy release")
 
     def TurnOnDisplay(self):
-        self.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
-        self.send_data(0xF7)
-        self.send_command(0x20) # MASTER_ACTIVATION
+        epdconfig.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
+        epdconfig.send_data(0xF7)
+        epdconfig.send_command(0x20) # MASTER_ACTIVATION
         self.ReadBusy()
     
     def TurnOnDisplayPart(self):
-        self.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
-        self.send_data(0xFF)
-        self.send_command(0x20) # MASTER_ACTIVATION
+        epdconfig.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
+        epdconfig.send_data(0xFF)
+        epdconfig.send_command(0x20) # MASTER_ACTIVATION
         self.ReadBusy()
 
     def init(self):
@@ -87,53 +63,53 @@ class EPD:
             return -1
             
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
         self.ReadBusy()
-        self.send_command(0x12) # SWRESET
+        epdconfig.send_command(0x12) # SWRESET
         self.ReadBusy()
         
-        self.send_command(0x01) # DRIVER_OUTPUT_CONTROL
-        self.send_data(0xC7) # (EPD_HEIGHT - 1) & 0xFF
-        self.send_data(0x00) # ((EPD_HEIGHT - 1) >> 8) & 0xFF
-        self.send_data(0x01) # GD = 0 SM = 0 TB = 0
+        epdconfig.send_command(0x01) # DRIVER_OUTPUT_CONTROL
+        epdconfig.send_data(0xC7) # (EPD_HEIGHT - 1) & 0xFF
+        epdconfig.send_data(0x00) # ((EPD_HEIGHT - 1) >> 8) & 0xFF
+        epdconfig.send_data(0x01) # GD = 0 SM = 0 TB = 0
         
-        self.send_command(0x11) # data entry mode
-        self.send_data(0x01)
+        epdconfig.send_command(0x11) # data entry mode
+        epdconfig.send_data(0x01)
         
-        self.send_command(0x44) # set Ram-X address start/end position
-        self.send_data(0x00)
-        self.send_data(0x18) # 0x0C-->(18+1)*8=200
+        epdconfig.send_command(0x44) # set Ram-X address start/end position
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x18) # 0x0C-->(18+1)*8=200
         
-        self.send_command(0x45) # set Ram-Y address start/end position
-        self.send_data(0xC7) # 0xC7-->(199+1)=200
-        self.send_data(0x00)
-        self.send_data(0x00)
-        self.send_data(0x00)
+        epdconfig.send_command(0x45) # set Ram-Y address start/end position
+        epdconfig.send_data(0xC7) # 0xC7-->(199+1)=200
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00)
 
-        self.send_command(0x3C) # BorderWavefrom
-        self.send_data(0x01)
+        epdconfig.send_command(0x3C) # BorderWavefrom
+        epdconfig.send_data(0x01)
 
-        self.send_command(0x18)
-        self.send_data(0x80)
+        epdconfig.send_command(0x18)
+        epdconfig.send_data(0x80)
 
-        self.send_command(0x22) # #Load Temperature and waveform setting.
-        self.send_data(0XB1)
-        self.send_command(0x20)
+        epdconfig.send_command(0x22) # #Load Temperature and waveform setting.
+        epdconfig.send_data(0XB1)
+        epdconfig.send_command(0x20)
 
-        self.send_command(0x4E) # set RAM x address count to 0;
-        self.send_data(0x00)
-        self.send_command(0x4F) # set RAM y address count to 0X199;
-        self.send_data(0xC7)
-        self.send_data(0x00)
+        epdconfig.send_command(0x4E) # set RAM x address count to 0;
+        epdconfig.send_data(0x00)
+        epdconfig.send_command(0x4F) # set RAM y address count to 0X199;
+        epdconfig.send_data(0xC7)
+        epdconfig.send_data(0x00)
         
         self.ReadBusy()
         
     def Clear(self, color):
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(color)
+                epdconfig.send_data(color)
                 
         self.TurnOnDisplay()
         
@@ -163,25 +139,25 @@ class EPD:
         if (image == None):
             return
             
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(image[i + j * int(self.width / 8)])   
+                epdconfig.send_data(image[i + j * int(self.width / 8)])   
         self.TurnOnDisplay()
         
     def displayPartBaseImage(self, image):
         if (image == None):
             return
         
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(image[i + j * int(self.width / 8)])
+                epdconfig.send_data(image[i + j * int(self.width / 8)])
         
-        self.send_command(0x26)
+        epdconfig.send_command(0x26)
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(image[i + j * int(self.width / 8)])
+                epdconfig.send_data(image[i + j * int(self.width / 8)])
                 
         self.TurnOnDisplayPart()
         
@@ -194,19 +170,19 @@ class EPD:
         epdconfig.digital_write(self.reset_pin, 1)
         epdconfig.delay_ms(10)   
         
-        self.send_command(0x3c)
-        self.send_data(0x80)
+        epdconfig.send_command(0x3c)
+        epdconfig.send_data(0x80)
         
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(image[i + j * int(self.width / 8)])
+                epdconfig.send_data(image[i + j * int(self.width / 8)])
                 
         self.TurnOnDisplayPart()
         
     def sleep(self):
-        self.send_command(0x10) # DEEP_SLEEP_MODE
-        self.send_data(0x01)
+        epdconfig.send_command(0x10) # DEEP_SLEEP_MODE
+        epdconfig.send_data(0x01)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54b.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54b.py
@@ -36,10 +36,7 @@ EPD_HEIGHT      = 200
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
 
@@ -50,28 +47,7 @@ class EPD:
     lut_g2 = [0x8E, 0x94, 0x01, 0x8A, 0x06, 0x04, 0x8A, 0x4A, 0x0F, 0x83, 0x43, 0x0C, 0x06, 0x0A, 0x04]
     lut_vcom1 = [0x03, 0x1D, 0x01, 0x01, 0x08, 0x23, 0x37, 0x37, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
     lut_red0 = [0x83, 0x5D, 0x01, 0x81, 0x48, 0x23, 0x77, 0x77, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
-    lut_red1 = [0x03, 0x1D, 0x01, 0x01, 0x08, 0x23, 0x37, 0x37, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00] 
-    
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0) # module reset
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
+    lut_red1 = [0x03, 0x1D, 0x01, 0x01, 0x08, 0x23, 0x37, 0x37, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]     
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -80,64 +56,64 @@ class EPD:
         logging.debug("e-Paper busy release")
       
     def set_lut_bw(self):
-        self.send_command(0x20) # vcom
+        epdconfig.send_command(0x20) # vcom
         for count in range(0, 15):
-            self.send_data(self.lut_vcom0[count])
-        self.send_command(0x21) # ww --
+            epdconfig.send_data(self.lut_vcom0[count])
+        epdconfig.send_command(0x21) # ww --
         for count in range(0, 15):
-            self.send_data(self.lut_w[count])
-        self.send_command(0x22) # bw r
+            epdconfig.send_data(self.lut_w[count])
+        epdconfig.send_command(0x22) # bw r
         for count in range(0, 15):
-            self.send_data(self.lut_b[count])
-        self.send_command(0x23) # wb w
+            epdconfig.send_data(self.lut_b[count])
+        epdconfig.send_command(0x23) # wb w
         for count in range(0, 15):
-            self.send_data(self.lut_g1[count])
-        self.send_command(0x24) # bb b
+            epdconfig.send_data(self.lut_g1[count])
+        epdconfig.send_command(0x24) # bb b
         for count in range(0, 15):
-            self.send_data(self.lut_g2[count])
+            epdconfig.send_data(self.lut_g2[count])
 
     def set_lut_red(self):
-        self.send_command(0x25)
+        epdconfig.send_command(0x25)
         for count in range(0, 15):
-            self.send_data(self.lut_vcom1[count])
-        self.send_command(0x26)
+            epdconfig.send_data(self.lut_vcom1[count])
+        epdconfig.send_command(0x26)
         for count in range(0, 15):
-            self.send_data(self.lut_red0[count])
-        self.send_command(0x27)
+            epdconfig.send_data(self.lut_red0[count])
+        epdconfig.send_command(0x27)
         for count in range(0, 15):
-            self.send_data(self.lut_red1[count])
+            epdconfig.send_data(self.lut_red1[count])
             
     def init(self):
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
-        self.send_command(0x01) # POWER_SETTING
-        self.send_data(0x07)
-        self.send_data(0x00)
-        self.send_data(0x08)
-        self.send_data(0x00)
-        self.send_command(0x06) # BOOSTER_SOFT_START
-        self.send_data(0x07)
-        self.send_data(0x07)
-        self.send_data(0x07)
-        self.send_command(0x04) # POWER_ON
+        epdconfig.send_command(0x01) # POWER_SETTING
+        epdconfig.send_data(0x07)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x08)
+        epdconfig.send_data(0x00)
+        epdconfig.send_command(0x06) # BOOSTER_SOFT_START
+        epdconfig.send_data(0x07)
+        epdconfig.send_data(0x07)
+        epdconfig.send_data(0x07)
+        epdconfig.send_command(0x04) # POWER_ON
 
         self.ReadBusy()
 
-        self.send_command(0X00) # PANEL_SETTING
-        self.send_data(0xCF)
-        self.send_command(0X50) # VCOM_AND_DATA_INTERVAL_SETTING
-        self.send_data(0x17)
-        self.send_command(0x30) # PLL_CONTROL
-        self.send_data(0x39)
-        self.send_command(0x61) # TCON_RESOLUTION set x and y
-        self.send_data(0xC8)
-        self.send_data(0x00)
-        self.send_data(0xC8)
-        self.send_command(0x82) # VCM_DC_SETTING_REGISTER
-        self.send_data(0x0E)
+        epdconfig.send_command(0X00) # PANEL_SETTING
+        epdconfig.send_data(0xCF)
+        epdconfig.send_command(0X50) # VCOM_AND_DATA_INTERVAL_SETTING
+        epdconfig.send_data(0x17)
+        epdconfig.send_command(0x30) # PLL_CONTROL
+        epdconfig.send_data(0x39)
+        epdconfig.send_command(0x61) # TCON_RESOLUTION set x and y
+        epdconfig.send_data(0xC8)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0xC8)
+        epdconfig.send_command(0x82) # VCM_DC_SETTING_REGISTER
+        epdconfig.send_data(0x0E)
         
         self.set_lut_bw()
         self.set_lut_red()
@@ -164,54 +140,54 @@ class EPD:
     def display(self, blackimage, redimage):
         # send black data
         if (blackimage != None):
-            self.send_command(0x10) # DATA_START_TRANSMISSION_1
+            epdconfig.send_command(0x10) # DATA_START_TRANSMISSION_1
             for i in range(0, int(self.width * self.height / 8)):
                 temp = 0x00
                 for bit in range(0, 4):
                     if (blackimage[i] & (0x80 >> bit) != 0):
                         temp |= 0xC0 >> (bit * 2)
-                self.send_data(temp)  
+                epdconfig.send_data(temp)  
                 temp = 0x00
                 for bit in range(4, 8):
                     if (blackimage[i] & (0x80 >> bit) != 0):
                         temp |= 0xC0 >> ((bit - 4) * 2)
-                self.send_data(temp)
+                epdconfig.send_data(temp)
                 
         # send red data        
         if (redimage != None):
-            self.send_command(0x13) # DATA_START_TRANSMISSION_2
+            epdconfig.send_command(0x13) # DATA_START_TRANSMISSION_2
             for i in range(0, int(self.width * self.height / 8)):
-                self.send_data(redimage[i])  
+                epdconfig.send_data(redimage[i])  
 
-        self.send_command(0x12) # DISPLAY_REFRESH
+        epdconfig.send_command(0x12) # DISPLAY_REFRESH
         self.ReadBusy()
 
     def Clear(self):
-        self.send_command(0x10) # DATA_START_TRANSMISSION_1
+        epdconfig.send_command(0x10) # DATA_START_TRANSMISSION_1
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
-            self.send_data(0xFF)
+            epdconfig.send_data(0xFF)
+            epdconfig.send_data(0xFF)
             
-        self.send_command(0x13) # DATA_START_TRANSMISSION_2
+        epdconfig.send_command(0x13) # DATA_START_TRANSMISSION_2
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            epdconfig.send_data(0xFF)
 
-        self.send_command(0x12) # DISPLAY_REFRESH
+        epdconfig.send_command(0x12) # DISPLAY_REFRESH
         self.ReadBusy()
 
     def sleep(self):
-        self.send_command(0x50) # VCOM_AND_DATA_INTERVAL_SETTING
-        self.send_data(0x17)
-        self.send_command(0x82) # to solve Vcom drop 
-        self.send_data(0x00)        
-        self.send_command(0x01) # power setting      
-        self.send_data(0x02) # gate switch to external
-        self.send_data(0x00)
-        self.send_data(0x00) 
-        self.send_data(0x00) 
+        epdconfig.send_command(0x50) # VCOM_AND_DATA_INTERVAL_SETTING
+        epdconfig.send_data(0x17)
+        epdconfig.send_command(0x82) # to solve Vcom drop 
+        epdconfig.send_data(0x00)        
+        epdconfig.send_command(0x01) # power setting      
+        epdconfig.send_data(0x02) # gate switch to external
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00) 
+        epdconfig.send_data(0x00) 
         self.ReadBusy()
         
-        self.send_command(0x02) # power off
+        epdconfig.send_command(0x02) # power off
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54b_V2.py
@@ -36,35 +36,10 @@ EPD_HEIGHT      = 200
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
-        self.height = EPD_HEIGHT
-
-
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0) # module reset
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
-        
+        self.height = EPD_HEIGHT 
+ 
     def ReadBusy(self):
         logging.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 1):
@@ -75,41 +50,41 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
         self.ReadBusy()   
-        self.send_command(0x12)  #SWRESET
+        epdconfig.send_command(0x12)  #SWRESET
         self.ReadBusy()   
 
-        self.send_command(0x01) #Driver output control      
-        self.send_data(0xC7)
-        self.send_data(0x00)
-        self.send_data(0x01)
+        epdconfig.send_command(0x01) #Driver output control      
+        epdconfig.send_data(0xC7)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x01)
 
-        self.send_command(0x11) #data entry mode       
-        self.send_data(0x01)
+        epdconfig.send_command(0x11) #data entry mode       
+        epdconfig.send_data(0x01)
 
-        self.send_command(0x44) #set Ram-X address start/end position   
-        self.send_data(0x00)
-        self.send_data(0x18)    #0x18-->(24+1)*8=200
+        epdconfig.send_command(0x44) #set Ram-X address start/end position   
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x18)    #0x18-->(24+1)*8=200
 
-        self.send_command(0x45) #set Ram-Y address start/end position          
-        self.send_data(0xC7)    #0xC7-->(199+1)=200
-        self.send_data(0x00)
-        self.send_data(0x00)
-        self.send_data(0x00) 
+        epdconfig.send_command(0x45) #set Ram-Y address start/end position          
+        epdconfig.send_data(0xC7)    #0xC7-->(199+1)=200
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00) 
 
-        self.send_command(0x3C) #BorderWavefrom
-        self.send_data(0x05)
+        epdconfig.send_command(0x3C) #BorderWavefrom
+        epdconfig.send_data(0x05)
 
-        self.send_command(0x18) #Read built-in temperature sensor
-        self.send_data(0x80)
+        epdconfig.send_command(0x18) #Read built-in temperature sensor
+        epdconfig.send_data(0x80)
 
-        self.send_command(0x4E)   # set RAM x address count to 0
-        self.send_data(0x00)
-        self.send_command(0x4F)   # set RAM y address count to 0X199    
-        self.send_data(0xC7)
-        self.send_data(0x00)
+        epdconfig.send_command(0x4E)   # set RAM x address count to 0
+        epdconfig.send_data(0x00)
+        epdconfig.send_command(0x4F)   # set RAM y address count to 0X199    
+        epdconfig.send_data(0xC7)
+        epdconfig.send_data(0x00)
         self.ReadBusy()
         return 0
 
@@ -134,39 +109,39 @@ class EPD:
     def display(self, blackimage, redimage):
         # send black data
         if (blackimage != None):
-            self.send_command(0x24) # DATA_START_TRANSMISSION_1
+            epdconfig.send_command(0x24) # DATA_START_TRANSMISSION_1
             for i in range(0, int(self.width * self.height / 8)):
-                self.send_data(blackimage[i])
+                epdconfig.send_data(blackimage[i])
                 
         # send red data        
         if (redimage != None):
-            self.send_command(0x26) # DATA_START_TRANSMISSION_2
+            epdconfig.send_command(0x26) # DATA_START_TRANSMISSION_2
             for i in range(0, int(self.width * self.height / 8)):
-                self.send_data(~redimage[i])  
+                epdconfig.send_data(~redimage[i])  
 
-        self.send_command(0x22) # DISPLAY_REFRESH
-        self.send_data(0xF7)
-        self.send_command(0x20) # DISPLAY_REFRESH
+        epdconfig.send_command(0x22) # DISPLAY_REFRESH
+        epdconfig.send_data(0xF7)
+        epdconfig.send_command(0x20) # DISPLAY_REFRESH
         self.ReadBusy()
 
     def Clear(self):
-        self.send_command(0x24) # DATA_START_TRANSMISSION_1
+        epdconfig.send_command(0x24) # DATA_START_TRANSMISSION_1
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            epdconfig.send_data(0xFF)
             
-        self.send_command(0x26) # DATA_START_TRANSMISSION_2
+        epdconfig.send_command(0x26) # DATA_START_TRANSMISSION_2
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
+            epdconfig.send_data(0x00)
 
-        self.send_command(0x22) # DISPLAY_REFRESH
-        self.send_data(0xF7)
-        self.send_command(0x20) # DISPLAY_REFRESH
+        epdconfig.send_command(0x22) # DISPLAY_REFRESH
+        epdconfig.send_data(0xF7)
+        epdconfig.send_command(0x20) # DISPLAY_REFRESH
         self.ReadBusy()
 
 
     def sleep(self):
-        self.send_command(0x10) #enter deep sleep
-        self.send_data(0x01) 
+        epdconfig.send_command(0x10) #enter deep sleep
+        epdconfig.send_data(0x01) 
 
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54c.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54c.py
@@ -35,33 +35,9 @@ EPD_HEIGHT      = 152
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(10) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(1)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(10)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):        
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -73,27 +49,27 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(10, 1, 10)
         
-        self.send_command(0x06) # boost soft start
-        self.send_data(0x17)
-        self.send_data(0x17)
-        self.send_data(0x17)
-        self.send_command(0x04) # power on
+        epdconfig.send_command(0x06) # boost soft start
+        epdconfig.send_data(0x17)
+        epdconfig.send_data(0x17)
+        epdconfig.send_data(0x17)
+        epdconfig.send_command(0x04) # power on
         
         self.ReadBusy()
         
-        self.send_command(0x00) # panel setting
-        self.send_data(0x0f) # LUT from OTP,160x296
-        self.send_data(0x0d) # VCOM to 0V fast
+        epdconfig.send_command(0x00) # panel setting
+        epdconfig.send_data(0x0f) # LUT from OTP,160x296
+        epdconfig.send_data(0x0d) # VCOM to 0V fast
         
-        self.send_command(0x61) # resolution setting
-        self.send_data(0x98)
-        self.send_data(0x00)
-        self.send_data(0x98)
+        epdconfig.send_command(0x61) # resolution setting
+        epdconfig.send_data(0x98)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x98)
         
-        self.send_command(0x50)
-        self.send_data(0x77)
+        epdconfig.send_command(0x50)
+        epdconfig.send_data(0x77)
 
     def getbuffer(self, image):
         buf = [0xFF] * (int(self.width/8) * self.height)
@@ -118,35 +94,35 @@ class EPD:
         return buf
 
     def display(self, blackimage, yellowimage):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         logging.debug("blackimage")
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(blackimage[i])
-        self.send_command(0x13)
+            epdconfig.send_data(blackimage[i])
+        epdconfig.send_command(0x13)
         logging.debug("yellowimage")
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(yellowimage[i])
+            epdconfig.send_data(yellowimage[i])
             
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         self.ReadBusy()
         
     def Clear(self):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)            
-        self.send_command(0x13)
+            epdconfig.send_data(0xFF)            
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            epdconfig.send_data(0xFF)
             
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         self.ReadBusy()
 
     #  after this, call epd.init() to awaken the module
     def sleep(self):
-        self.send_command(0X02)  #  power off
+        epdconfig.send_command(0X02)  #  power off
         self.ReadBusy() 
-        self.send_command(0X07)  #  deep sleep
-        self.send_data(0xA5)
+        epdconfig.send_command(0X07)  #  deep sleep
+        epdconfig.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13.py
@@ -38,10 +38,7 @@ EPD_HEIGHT      = 250
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
         
@@ -57,38 +54,17 @@ class EPD:
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x0F, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-    ]
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
-        
+    ]  
+       
     def ReadBusy(self):        
         while(epdconfig.digital_read(self.busy_pin) == 1):      # 0: idle, 1: busy
             epdconfig.delay_ms(100)            
 
     def TurnOnDisplay(self):
-        self.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
-        self.send_data(0xC4)
-        self.send_command(0x20) # MASTER_ACTIVATION
-        self.send_command(0xFF) # TERMINATE_FRAME_READ_WRITE
+        epdconfig.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
+        epdconfig.send_data(0xC4)
+        epdconfig.send_command(0x20) # MASTER_ACTIVATION
+        epdconfig.send_command(0xFF) # TERMINATE_FRAME_READ_WRITE
         
         logging.debug("e-Paper busy")
         self.ReadBusy()
@@ -98,36 +74,36 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
-        self.send_command(0x01) # DRIVER_OUTPUT_CONTROL
-        self.send_data((EPD_HEIGHT - 1) & 0xFF)
-        self.send_data(((EPD_HEIGHT - 1) >> 8) & 0xFF)
-        self.send_data(0x00) # GD = 0 SM = 0 TB = 0
+        epdconfig.reset(200, 5, 200)
+        epdconfig.send_command(0x01) # DRIVER_OUTPUT_CONTROL
+        epdconfig.send_data((EPD_HEIGHT - 1) & 0xFF)
+        epdconfig.send_data(((EPD_HEIGHT - 1) >> 8) & 0xFF)
+        epdconfig.send_data(0x00) # GD = 0 SM = 0 TB = 0
         
-        self.send_command(0x0C) # BOOSTER_SOFT_START_CONTROL
-        self.send_data(0xD7)
-        self.send_data(0xD6)
-        self.send_data(0x9D)
+        epdconfig.send_command(0x0C) # BOOSTER_SOFT_START_CONTROL
+        epdconfig.send_data(0xD7)
+        epdconfig.send_data(0xD6)
+        epdconfig.send_data(0x9D)
         
-        self.send_command(0x2C) # WRITE_VCOM_REGISTER
-        self.send_data(0xA8) # VCOM 7C
+        epdconfig.send_command(0x2C) # WRITE_VCOM_REGISTER
+        epdconfig.send_data(0xA8) # VCOM 7C
         
-        self.send_command(0x3A) # SET_DUMMY_LINE_PERIOD
-        self.send_data(0x1A) # 4 dummy lines per gate
+        epdconfig.send_command(0x3A) # SET_DUMMY_LINE_PERIOD
+        epdconfig.send_data(0x1A) # 4 dummy lines per gate
         
-        self.send_command(0x3B) # SET_GATE_TIME
-        self.send_data(0x08) # 2us per line
+        epdconfig.send_command(0x3B) # SET_GATE_TIME
+        epdconfig.send_data(0x08) # 2us per line
         
-        self.send_command(0X3C) # BORDER_WAVEFORM_CONTROL
-        self.send_data(0x03)      
+        epdconfig.send_command(0X3C) # BORDER_WAVEFORM_CONTROL
+        epdconfig.send_data(0x03)      
         
-        self.send_command(0X11) # DATA_ENTRY_MODE_SETTING
-        self.send_data(0x03) # X increment; Y increment
+        epdconfig.send_command(0X11) # DATA_ENTRY_MODE_SETTING
+        epdconfig.send_data(0x03) # X increment; Y increment
         
         # WRITE_LUT_REGISTER
-        self.send_command(0x32)
+        epdconfig.send_command(0x32)
         for count in range(30):
-            self.send_data(lut[count])
+            epdconfig.send_data(lut[count])
 
         return 0
         
@@ -135,25 +111,25 @@ class EPD:
  #  @brief: specify the memory area for data R/W
  ##
     def SetWindows(self, x_start, y_start, x_end, y_end):
-        self.send_command(0x44) # SET_RAM_X_ADDRESS_START_END_POSITION
-        self.send_data((x_start >> 3) & 0xFF)
-        self.send_data((x_end >> 3) & 0xFF)
-        self.send_command(0x45) # SET_RAM_Y_ADDRESS_START_END_POSITION
-        self.send_data(y_start & 0xFF)
-        self.send_data((y_start >> 8) & 0xFF)
-        self.send_data(y_end & 0xFF)
-        self.send_data((y_end >> 8) & 0xFF)
+        epdconfig.send_command(0x44) # SET_RAM_X_ADDRESS_START_END_POSITION
+        epdconfig.send_data((x_start >> 3) & 0xFF)
+        epdconfig.send_data((x_end >> 3) & 0xFF)
+        epdconfig.send_command(0x45) # SET_RAM_Y_ADDRESS_START_END_POSITION
+        epdconfig.send_data(y_start & 0xFF)
+        epdconfig.send_data((y_start >> 8) & 0xFF)
+        epdconfig.send_data(y_end & 0xFF)
+        epdconfig.send_data((y_end >> 8) & 0xFF)
 
 ##
  #  @brief: specify the start point for data R/W
  ##
     def SetCursor(self, x, y):
-        self.send_command(0x4E) # SET_RAM_X_ADDRESS_COUNTER
+        epdconfig.send_command(0x4E) # SET_RAM_X_ADDRESS_COUNTER
         # x point must be the multiple of 8 or the last 3 bits will be ignored
-        self.send_data((x >> 3) & 0xFF)
-        self.send_command(0x4F) # SET_RAM_Y_ADDRESS_COUNTER
-        self.send_data(y & 0xFF)
-        self.send_data((y >> 8) & 0xFF)
+        epdconfig.send_data((x >> 3) & 0xFF)
+        epdconfig.send_command(0x4F) # SET_RAM_Y_ADDRESS_COUNTER
+        epdconfig.send_data(y & 0xFF)
+        epdconfig.send_data((y >> 8) & 0xFF)
         self.ReadBusy()
         
     def getbuffer(self, image):
@@ -195,9 +171,9 @@ class EPD:
         self.SetWindows(0, 0, self.width, self.height);
         for j in range(0, self.height):
             self.SetCursor(0, j);
-            self.send_command(0x24);
+            epdconfig.send_command(0x24);
             for i in range(0, linewidth):
-                self.send_data(image[i + j * linewidth])   
+                epdconfig.send_data(image[i + j * linewidth])   
         self.TurnOnDisplay()
     
     def Clear(self, color):
@@ -209,14 +185,14 @@ class EPD:
         self.SetWindows(0, 0, self.width, self.height);
         for j in range(0, self.height):
             self.SetCursor(0, j);
-            self.send_command(0x24);
+            epdconfig.send_command(0x24);
             for i in range(0, linewidth):
-                self.send_data(color)   
+                epdconfig.send_data(color)   
         self.TurnOnDisplay()
 
     def sleep(self):
-        self.send_command(0x10) #enter deep sleep
-        self.send_data(0x01)
+        epdconfig.send_command(0x10) #enter deep sleep
+        epdconfig.send_data(0x01)
         epdconfig.delay_ms(100)
          
         epdconfig.delay_ms(2000)

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V2.py
@@ -38,10 +38,7 @@ EPD_HEIGHT      = 250
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
         
@@ -81,133 +78,112 @@ class EPD:
         0x00,0x00,0x00,0x00,0x00,                       # TP6 A~D RP6
 
         0x15,0x41,0xA8,0x32,0x30,0x0A,
-    ]
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
+    ]  
         
     def ReadBusy(self):
         while(epdconfig.digital_read(self.busy_pin) == 1):      # 0: idle, 1: busy
             epdconfig.delay_ms(100)    
 
     def TurnOnDisplay(self):
-        self.send_command(0x22)
-        self.send_data(0xC7)
-        self.send_command(0x20)        
+        epdconfig.send_command(0x22)
+        epdconfig.send_data(0xC7)
+        epdconfig.send_command(0x20)        
         self.ReadBusy()
         
     def TurnOnDisplayPart(self):
-        self.send_command(0x22)
-        self.send_data(0x0c)
-        self.send_command(0x20)        
+        epdconfig.send_command(0x22)
+        epdconfig.send_data(0x0c)
+        epdconfig.send_command(0x20)        
         self.ReadBusy()
         
     def init(self, update):
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         if(update == self.FULL_UPDATE):
             self.ReadBusy()
-            self.send_command(0x12) # soft reset
+            epdconfig.send_command(0x12) # soft reset
             self.ReadBusy()
 
-            self.send_command(0x74) #set analog block control
-            self.send_data(0x54)
-            self.send_command(0x7E) #set digital block control
-            self.send_data(0x3B)
+            epdconfig.send_command(0x74) #set analog block control
+            epdconfig.send_data(0x54)
+            epdconfig.send_command(0x7E) #set digital block control
+            epdconfig.send_data(0x3B)
 
-            self.send_command(0x01) #Driver output control
-            self.send_data(0xF9)
-            self.send_data(0x00)
-            self.send_data(0x00)
+            epdconfig.send_command(0x01) #Driver output control
+            epdconfig.send_data(0xF9)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
 
-            self.send_command(0x11) #data entry mode
-            self.send_data(0x01)
+            epdconfig.send_command(0x11) #data entry mode
+            epdconfig.send_data(0x01)
 
-            self.send_command(0x44) #set Ram-X address start/end position
-            self.send_data(0x00)
-            self.send_data(0x0F)    #0x0C-->(15+1)*8=128
+            epdconfig.send_command(0x44) #set Ram-X address start/end position
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x0F)    #0x0C-->(15+1)*8=128
 
-            self.send_command(0x45) #set Ram-Y address start/end position
-            self.send_data(0xF9)   #0xF9-->(249+1)=250
-            self.send_data(0x00)
-            self.send_data(0x00)
-            self.send_data(0x00)
+            epdconfig.send_command(0x45) #set Ram-Y address start/end position
+            epdconfig.send_data(0xF9)   #0xF9-->(249+1)=250
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
             
-            self.send_command(0x3C) #BorderWavefrom
-            self.send_data(0x03)
+            epdconfig.send_command(0x3C) #BorderWavefrom
+            epdconfig.send_data(0x03)
 
-            self.send_command(0x2C)     #VCOM Voltage
-            self.send_data(0x55)    #
+            epdconfig.send_command(0x2C)     #VCOM Voltage
+            epdconfig.send_data(0x55)    #
 
-            self.send_command(0x03)
-            self.send_data(self.lut_full_update[70])
+            epdconfig.send_command(0x03)
+            epdconfig.send_data(self.lut_full_update[70])
 
-            self.send_command(0x04) #
-            self.send_data(self.lut_full_update[71])
-            self.send_data(self.lut_full_update[72])
-            self.send_data(self.lut_full_update[73])
+            epdconfig.send_command(0x04) #
+            epdconfig.send_data(self.lut_full_update[71])
+            epdconfig.send_data(self.lut_full_update[72])
+            epdconfig.send_data(self.lut_full_update[73])
 
-            self.send_command(0x3A)     #Dummy Line
-            self.send_data(self.lut_full_update[74])
-            self.send_command(0x3B)     #Gate time
-            self.send_data(self.lut_full_update[75])
+            epdconfig.send_command(0x3A)     #Dummy Line
+            epdconfig.send_data(self.lut_full_update[74])
+            epdconfig.send_command(0x3B)     #Gate time
+            epdconfig.send_data(self.lut_full_update[75])
 
-            self.send_command(0x32)
+            epdconfig.send_command(0x32)
             for count in range(70):
-                self.send_data(self.lut_full_update[count])
+                epdconfig.send_data(self.lut_full_update[count])
 
-            self.send_command(0x4E)   # set RAM x address count to 0
-            self.send_data(0x00)
-            self.send_command(0x4F)   # set RAM y address count to 0X127
-            self.send_data(0xF9)
-            self.send_data(0x00)
+            epdconfig.send_command(0x4E)   # set RAM x address count to 0
+            epdconfig.send_data(0x00)
+            epdconfig.send_command(0x4F)   # set RAM y address count to 0X127
+            epdconfig.send_data(0xF9)
+            epdconfig.send_data(0x00)
             self.ReadBusy()
         else:
-            self.send_command(0x2C)     #VCOM Voltage
-            self.send_data(0x26)
+            epdconfig.send_command(0x2C)     #VCOM Voltage
+            epdconfig.send_data(0x26)
 
             self.ReadBusy()
 
-            self.send_command(0x32)
+            epdconfig.send_command(0x32)
             for count in range(70):
-                self.send_data(self.lut_partial_update[count])
+                epdconfig.send_data(self.lut_partial_update[count])
 
-            self.send_command(0x37)
-            self.send_data(0x00)
-            self.send_data(0x00)
-            self.send_data(0x00)
-            self.send_data(0x00)
-            self.send_data(0x40)
-            self.send_data(0x00)
-            self.send_data(0x00)
+            epdconfig.send_command(0x37)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x40)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
 
-            self.send_command(0x22)
-            self.send_data(0xC0)
-            self.send_command(0x20)
+            epdconfig.send_command(0x22)
+            epdconfig.send_data(0xC0)
+            epdconfig.send_command(0x20)
             self.ReadBusy()
 
-            self.send_command(0x3C) #BorderWavefrom
-            self.send_data(0x01)
+            epdconfig.send_command(0x3C) #BorderWavefrom
+            epdconfig.send_data(0x01)
         return 0
 
     def getbuffer(self, image):
@@ -246,10 +222,10 @@ class EPD:
         else:
             linewidth = int(self.width/8) + 1
 
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for j in range(0, self.height):
             for i in range(0, linewidth):
-                self.send_data(image[i + j * linewidth])   
+                epdconfig.send_data(image[i + j * linewidth])   
         self.TurnOnDisplay()
         
     def displayPartial(self, image):
@@ -258,16 +234,16 @@ class EPD:
         else:
             linewidth = int(self.width/8) + 1
 
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for j in range(0, self.height):
             for i in range(0, linewidth):
-                self.send_data(image[i + j * linewidth])   
+                epdconfig.send_data(image[i + j * linewidth])   
                 
                 
-        self.send_command(0x26)
+        epdconfig.send_command(0x26)
         for j in range(0, self.height):
             for i in range(0, linewidth):
-                self.send_data(~image[i + j * linewidth])  
+                epdconfig.send_data(~image[i + j * linewidth])  
         self.TurnOnDisplayPart()
 
     def displayPartBaseImage(self, image):
@@ -276,16 +252,16 @@ class EPD:
         else:
             linewidth = int(self.width/8) + 1
 
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for j in range(0, self.height):
             for i in range(0, linewidth):
-                self.send_data(image[i + j * linewidth])   
+                epdconfig.send_data(image[i + j * linewidth])   
                 
                 
-        self.send_command(0x26)
+        epdconfig.send_command(0x26)
         for j in range(0, self.height):
             for i in range(0, linewidth):
-                self.send_data(image[i + j * linewidth])  
+                epdconfig.send_data(image[i + j * linewidth])  
         self.TurnOnDisplay()
     
     def Clear(self, color):
@@ -295,25 +271,25 @@ class EPD:
             linewidth = int(self.width/8) + 1
         # logging.debug(linewidth)
         
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for j in range(0, self.height):
             for i in range(0, linewidth):
-                self.send_data(color)
+                epdconfig.send_data(color)
                 
-        # self.send_command(0x26)
+        # epdconfig.send_command(0x26)
         # for j in range(0, self.height):
             # for i in range(0, linewidth):
-                # self.send_data(color)   
+                # epdconfig.send_data(color)   
                 
         self.TurnOnDisplay()
 
     def sleep(self):
-        # self.send_command(0x22) #POWER OFF
-        # self.send_data(0xC3)
-        # self.send_command(0x20)
+        # epdconfig.send_command(0x22) #POWER OFF
+        # epdconfig.send_data(0xC3)
+        # epdconfig.send_command(0x20)
 
-        self.send_command(0x10) #enter deep sleep
-        self.send_data(0x03)
+        epdconfig.send_command(0x10) #enter deep sleep
+        epdconfig.send_data(0x03)
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13b_V3.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13b_V3.py
@@ -36,39 +36,15 @@ EPD_HEIGHT      = 212
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
-        self.height = EPD_HEIGHT
-
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(2)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
+        self.height = EPD_HEIGHT 
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
-        self.send_command(0x71);
+        epdconfig.send_command(0x71);
         while(epdconfig.digital_read(self.busy_pin) == 0): 
-            self.send_command(0x71);
+            epdconfig.send_command(0x71);
             epdconfig.delay_ms(100)
         logging.debug("e-Paper busy release")
 
@@ -76,21 +52,21 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
             
-        self.reset()
-        self.send_command(0x04);  
+        epdconfig.reset(200, 2, 200)
+        epdconfig.send_command(0x04);  
         self.ReadBusy();#waiting for the electronic paper IC to release the idle signal
 
-        self.send_command(0x00);    #panel setting
-        self.send_data(0x0f);   #LUT from OTP,128x296
-        self.send_data(0x89);    #Temperature sensor, boost and other related timing settings
+        epdconfig.send_command(0x00);    #panel setting
+        epdconfig.send_data(0x0f);   #LUT from OTP,128x296
+        epdconfig.send_data(0x89);    #Temperature sensor, boost and other related timing settings
 
-        self.send_command(0x61);    #resolution setting
-        self.send_data (0x68);  
-        self.send_data (0x00);  
-        self.send_data (0xD4);
+        epdconfig.send_command(0x61);    #resolution setting
+        epdconfig.send_data (0x68);  
+        epdconfig.send_data (0x00);  
+        epdconfig.send_data (0xD4);
 
-        self.send_command(0X50);    #VCOM AND DATA INTERVAL SETTING
-        self.send_data(0x77);   #WBmode:VBDF 17|D7 VBDW 97 VBDB 57
+        epdconfig.send_command(0X50);    #VCOM AND DATA INTERVAL SETTING
+        epdconfig.send_data(0x77);   #WBmode:VBDF 17|D7 VBDW 97 VBDB 57
                             # WBRmode:VBDF F7 VBDW 77 VBDB 37  VBDR B7
         
         return 0
@@ -120,38 +96,38 @@ class EPD:
         return buf
 
     def display(self, imageblack, imagered):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(imageblack[i])
+            epdconfig.send_data(imageblack[i])
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(imagered[i])
+            epdconfig.send_data(imagered[i])
         
-        self.send_command(0x12) # REFRESH
+        epdconfig.send_command(0x12) # REFRESH
         epdconfig.delay_ms(100)
         self.ReadBusy()
         
     def Clear(self):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            epdconfig.send_data(0xFF)
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            epdconfig.send_data(0xFF)
         
-        self.send_command(0x12) # REFRESH
+        epdconfig.send_command(0x12) # REFRESH
         epdconfig.delay_ms(100)
         self.ReadBusy()
 
     def sleep(self):
-        self.send_command(0X50) 
-        self.send_data(0xf7)
-        self.send_command(0X02) 
+        epdconfig.send_command(0X50) 
+        epdconfig.send_data(0xf7)
+        epdconfig.send_command(0X02) 
         self.ReadBusy()
-        self.send_command(0x07) # DEEP_SLEEP
-        self.send_data(0xA5) # check code
+        epdconfig.send_command(0x07) # DEEP_SLEEP
+        epdconfig.send_data(0xA5) # check code
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13bc.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13bc.py
@@ -36,33 +36,9 @@ EPD_HEIGHT      = 212
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
-        self.height = EPD_HEIGHT
-
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
+        self.height = EPD_HEIGHT 
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -74,26 +50,26 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
             
-        self.reset()
+        epdconfig.reset(200, 5, 200)
 
-        self.send_command(0x06) # BOOSTER_SOFT_START
-        self.send_data(0x17)
-        self.send_data(0x17)
-        self.send_data(0x17)
+        epdconfig.send_command(0x06) # BOOSTER_SOFT_START
+        epdconfig.send_data(0x17)
+        epdconfig.send_data(0x17)
+        epdconfig.send_data(0x17)
         
-        self.send_command(0x04) # POWER_ON
+        epdconfig.send_command(0x04) # POWER_ON
         self.ReadBusy()
         
-        self.send_command(0x00) # PANEL_SETTING
-        self.send_data(0x8F)
+        epdconfig.send_command(0x00) # PANEL_SETTING
+        epdconfig.send_data(0x8F)
         
-        self.send_command(0x50) # VCOM_AND_DATA_INTERVAL_SETTING
-        self.send_data(0xF0)
+        epdconfig.send_command(0x50) # VCOM_AND_DATA_INTERVAL_SETTING
+        epdconfig.send_data(0xF0)
         
-        self.send_command(0x61) # RESOLUTION_SETTING
-        self.send_data(self.width & 0xff)
-        self.send_data(self.height >> 8)
-        self.send_data(self.height & 0xff)
+        epdconfig.send_command(0x61) # RESOLUTION_SETTING
+        epdconfig.send_data(self.width & 0xff)
+        epdconfig.send_data(self.height >> 8)
+        epdconfig.send_data(self.height & 0xff)
         return 0
 
     def getbuffer(self, image):
@@ -121,38 +97,38 @@ class EPD:
         return buf
 
     def display(self, imageblack, imagered):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(imageblack[i])
-        # self.send_command(0x92)
+            epdconfig.send_data(imageblack[i])
+        # epdconfig.send_command(0x92)
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(imagered[i])
-        # self.send_command(0x92)
+            epdconfig.send_data(imagered[i])
+        # epdconfig.send_command(0x92)
         
-        self.send_command(0x12) # REFRESH
+        epdconfig.send_command(0x12) # REFRESH
         self.ReadBusy()
         
     def Clear(self):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
-        self.send_command(0x92) 
+            epdconfig.send_data(0xFF)
+        epdconfig.send_command(0x92) 
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
-        self.send_command(0x92)
+            epdconfig.send_data(0xFF)
+        epdconfig.send_command(0x92)
         
-        self.send_command(0x12) # REFRESH
+        epdconfig.send_command(0x12) # REFRESH
         self.ReadBusy()
 
     def sleep(self):
-        self.send_command(0x02) # POWER_OFF
+        epdconfig.send_command(0x02) # POWER_OFF
         self.ReadBusy()
-        self.send_command(0x07) # DEEP_SLEEP
-        self.send_data(0xA5) # check code
+        epdconfig.send_command(0x07) # DEEP_SLEEP
+        epdconfig.send_data(0xA5) # check code
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13d.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13d.py
@@ -39,10 +39,7 @@ EPD_HEIGHT      = 212
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
 
@@ -146,38 +143,17 @@ class EPD:
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    ]
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
+    ] 
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
-            self.send_command(0x71)
+            epdconfig.send_command(0x71)
             epdconfig.delay_ms(100)  
         logging.debug("e-Paper busy release")
         
     def TurnOnDisplay(self):
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(100)
         self.ReadBusy()
         
@@ -185,82 +161,82 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
-        self.send_command(0x01)	# POWER SETTING
-        self.send_data(0x03)
-        self.send_data(0x00)
-        self.send_data(0x2b)
-        self.send_data(0x2b)
-        self.send_data(0x03)
+        epdconfig.send_command(0x01)	# POWER SETTING
+        epdconfig.send_data(0x03)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x2b)
+        epdconfig.send_data(0x2b)
+        epdconfig.send_data(0x03)
 
-        self.send_command(0x06)	# boost soft start
-        self.send_data(0x17) # A
-        self.send_data(0x17) # B
-        self.send_data(0x17) # C
+        epdconfig.send_command(0x06)	# boost soft start
+        epdconfig.send_data(0x17) # A
+        epdconfig.send_data(0x17) # B
+        epdconfig.send_data(0x17) # C
 
-        self.send_command(0x04)
+        epdconfig.send_command(0x04)
         self.ReadBusy()
 
-        self.send_command(0x00)	# panel setting
-        self.send_data(0xbf) # LUT from OTP,128x296
-        self.send_data(0x0d) # VCOM to 0V fast
+        epdconfig.send_command(0x00)	# panel setting
+        epdconfig.send_data(0xbf) # LUT from OTP,128x296
+        epdconfig.send_data(0x0d) # VCOM to 0V fast
 
-        self.send_command(0x30)	# PLL setting
-        self.send_data(0x3a) # 3a 100HZ   29 150Hz 39 200HZ	31 171HZ
+        epdconfig.send_command(0x30)	# PLL setting
+        epdconfig.send_data(0x3a) # 3a 100HZ   29 150Hz 39 200HZ	31 171HZ
 
-        self.send_command(0x61)	# resolution setting
-        self.send_data(self.width)
-        self.send_data((self.height >> 8) & 0xff)
-        self.send_data(self.height& 0xff)
+        epdconfig.send_command(0x61)	# resolution setting
+        epdconfig.send_data(self.width)
+        epdconfig.send_data((self.height >> 8) & 0xff)
+        epdconfig.send_data(self.height& 0xff)
 
-        self.send_command(0x82)	# vcom_DC setting
-        self.send_data(0x28)
+        epdconfig.send_command(0x82)	# vcom_DC setting
+        epdconfig.send_data(0x28)
         return 0
         
     def SetFullReg(self):
-        self.send_command(0x82)
-        self.send_data(0x00)
-        self.send_command(0X50)
-        self.send_data(0x97)
+        epdconfig.send_command(0x82)
+        epdconfig.send_data(0x00)
+        epdconfig.send_command(0X50)
+        epdconfig.send_data(0x97)
         
-        self.send_command(0x20) # vcom
+        epdconfig.send_command(0x20) # vcom
         for count in range(0, 44):
-            self.send_data(self.lut_vcomDC[count])
-        self.send_command(0x21) # ww --
+            epdconfig.send_data(self.lut_vcomDC[count])
+        epdconfig.send_command(0x21) # ww --
         for count in range(0, 42):
-            self.send_data(self.lut_ww[count])
-        self.send_command(0x22) # bw r
+            epdconfig.send_data(self.lut_ww[count])
+        epdconfig.send_command(0x22) # bw r
         for count in range(0, 42):
-            self.send_data(self.lut_bw[count])
-        self.send_command(0x23) # wb w
+            epdconfig.send_data(self.lut_bw[count])
+        epdconfig.send_command(0x23) # wb w
         for count in range(0, 42):
-            self.send_data(self.lut_wb[count])
-        self.send_command(0x24) # bb b
+            epdconfig.send_data(self.lut_wb[count])
+        epdconfig.send_command(0x24) # bb b
         for count in range(0, 42):
-            self.send_data(self.lut_bb[count])
+            epdconfig.send_data(self.lut_bb[count])
     
     def SetPartReg(self):
-        self.send_command(0x82)
-        self.send_data(0x03)
-        self.send_command(0X50)
-        self.send_data(0x47)
+        epdconfig.send_command(0x82)
+        epdconfig.send_data(0x03)
+        epdconfig.send_command(0X50)
+        epdconfig.send_data(0x47)
         
-        self.send_command(0x20) # vcom
+        epdconfig.send_command(0x20) # vcom
         for count in range(0, 44):
-            self.send_data(self.lut_vcom1[count])
-        self.send_command(0x21) # ww --
+            epdconfig.send_data(self.lut_vcom1[count])
+        epdconfig.send_command(0x21) # ww --
         for count in range(0, 42):
-            self.send_data(self.lut_ww1[count])
-        self.send_command(0x22) # bw r
+            epdconfig.send_data(self.lut_ww1[count])
+        epdconfig.send_command(0x22) # bw r
         for count in range(0, 42):
-            self.send_data(self.lut_bw1[count])
-        self.send_command(0x23) # wb w
+            epdconfig.send_data(self.lut_bw1[count])
+        epdconfig.send_command(0x23) # wb w
         for count in range(0, 42):
-            self.send_data(self.lut_wb1[count])
-        self.send_command(0x24) # bb b
+            epdconfig.send_data(self.lut_wb1[count])
+        epdconfig.send_command(0x24) # bb b
         for count in range(0, 42):
-            self.send_data(self.lut_bb1[count])
+            epdconfig.send_data(self.lut_bb1[count])
 
     def getbuffer(self, image):
         # logging.debug("bufsiz = ",int(self.width/8) * self.height)
@@ -290,14 +266,14 @@ class EPD:
         if (Image == None):
             return
             
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
+            epdconfig.send_data(0x00)
         epdconfig.delay_ms(10)
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(image[i])
+            epdconfig.send_data(image[i])
         epdconfig.delay_ms(10)
         
         self.SetFullReg()
@@ -307,50 +283,50 @@ class EPD:
         if (Image == None):
             return
             
-        self.send_command(0x91)
-        self.send_command(0x90)
-        self.send_data(0)
-        self.send_data(self.width - 1)
+        epdconfig.send_command(0x91)
+        epdconfig.send_command(0x90)
+        epdconfig.send_data(0)
+        epdconfig.send_data(self.width - 1)
 
-        self.send_data(0)
-        self.send_data(0)
-        self.send_data(int(self.height / 256))
-        self.send_data(self.height % 256 - 1)
-        self.send_data(0x28)
+        epdconfig.send_data(0)
+        epdconfig.send_data(0)
+        epdconfig.send_data(int(self.height / 256))
+        epdconfig.send_data(self.height % 256 - 1)
+        epdconfig.send_data(0x28)
             
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(image[i])
+            epdconfig.send_data(image[i])
         epdconfig.delay_ms(10)
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(~image[i])
+            epdconfig.send_data(~image[i])
         epdconfig.delay_ms(10)
         
         self.SetPartReg()
         self.TurnOnDisplay()
         
     def Clear(self, color):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
+            epdconfig.send_data(0x00)
         epdconfig.delay_ms(10)
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            epdconfig.send_data(0xFF)
         epdconfig.delay_ms(10)
         
         self.SetFullReg()
         self.TurnOnDisplay()
 
     def sleep(self):
-        self.send_command(0X50)
-        self.send_data(0xf7)
-        self.send_command(0X02) # power off
-        self.send_command(0X07) # deep sleep  
-        self.send_data(0xA5)
+        epdconfig.send_command(0X50)
+        epdconfig.send_data(0xf7)
+        epdconfig.send_command(0X02) # power off
+        epdconfig.send_command(0X07) # deep sleep  
+        epdconfig.send_data(0xA5)
 
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in66.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in66.py
@@ -36,10 +36,7 @@ EPD_HEIGHT      = 296
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
 
@@ -62,31 +59,6 @@ class EPD:
         0x00,0x00,0x00,0x22,0x17,0x41,0xB0,0x32,0x36,
     ]
 
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-
     def ReadBusy(self):
         logging.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 1):      #  0: idle, 1: busy
@@ -98,48 +70,48 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(300)
         self.ReadBusy()
 
-        self.send_command(0x11) # setting gaet number
-        self.send_data(0x03)
-        self.send_command(0x44) # set gate voltage
-        self.send_data(0x01)
-        self.send_data(0x13)
-        self.send_command(0x45) # set source voltage
-        self.send_data(0x0)
-        self.send_data(0x0)
-        self.send_data(0x28)
-        self.send_data(0x01)
+        epdconfig.send_command(0x11) # setting gaet number
+        epdconfig.send_data(0x03)
+        epdconfig.send_command(0x44) # set gate voltage
+        epdconfig.send_data(0x01)
+        epdconfig.send_data(0x13)
+        epdconfig.send_command(0x45) # set source voltage
+        epdconfig.send_data(0x0)
+        epdconfig.send_data(0x0)
+        epdconfig.send_data(0x28)
+        epdconfig.send_data(0x01)
     
         if(mode == 0):      #full
-            self.send_command(0x3C)
-            self.send_data(0x01)
+            epdconfig.send_command(0x3C)
+            epdconfig.send_data(0x01)
             
         elif(mode == 1):        #partial
             self.load_lut(self.WF_PARTIAL)
-            self.send_command(0x37) # set display option, these setting turn on previous function
-            self.send_data(0x00)
-            self.send_data(0x00)
-            self.send_data(0x00)
-            self.send_data(0x00)
-            self.send_data(0x00)  
-            self.send_data(0x40)
-            self.send_data(0x00)
-            self.send_data(0x00)
-            self.send_data(0x00)
-            self.send_data(0x00)  
+            epdconfig.send_command(0x37) # set display option, these setting turn on previous function
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)  
+            epdconfig.send_data(0x40)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)  
 
-            self.send_command(0x3C)
-            self.send_data(0x80)
+            epdconfig.send_command(0x3C)
+            epdconfig.send_data(0x80)
 
-            self.send_command(0x22)
-            self.send_data(0xcf)
+            epdconfig.send_command(0x22)
+            epdconfig.send_data(0xcf)
             
-            self.send_command(0x20)
+            epdconfig.send_command(0x20)
             self.ReadBusy()
 
         else:
@@ -149,13 +121,13 @@ class EPD:
 
 
     def load_lut(self, lut):
-        self.send_command(0x32)
+        epdconfig.send_command(0x32)
         for i in range(0, 153):
-            self.send_data(lut[i])
+            epdconfig.send_data(lut[i])
 
 
     def turnon_display(self):
-        self.send_command(0x20)
+        epdconfig.send_command(0x20)
         self.ReadBusy()
 
     def getbuffer(self, image):
@@ -187,43 +159,43 @@ class EPD:
         if (image == None):
             return            
 
-        self.send_command(0x4E)
-        self.send_data(0x01)
-        self.send_command(0x4F)
-        self.send_data(0x27)
-        self.send_data(0x01)
+        epdconfig.send_command(0x4E)
+        epdconfig.send_data(0x01)
+        epdconfig.send_command(0x4F)
+        epdconfig.send_data(0x27)
+        epdconfig.send_data(0x01)
 
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(image[i + j * int(self.width / 8)])   
+                epdconfig.send_data(image[i + j * int(self.width / 8)])   
 
         self.turnon_display()
         
 
     def Clear(self):
-        self.send_command(0x4E)
-        self.send_data(0x01)
-        self.send_command(0x4F)
-        self.send_data(0x27)
-        self.send_data(0x01)
+        epdconfig.send_command(0x4E)
+        epdconfig.send_data(0x01)
+        epdconfig.send_command(0x4F)
+        epdconfig.send_data(0x27)
+        epdconfig.send_data(0x01)
 
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(0xff)   
+                epdconfig.send_data(0xff)   
 
-        self.send_command(0x26)
+        epdconfig.send_command(0x26)
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(0xff) 
+                epdconfig.send_data(0xff) 
 
         self.turnon_display()
 
 
     def sleep(self):
-        self.send_command(0X10) # DEEP_SLEEP_MODE
-        self.send_data(0x01)
+        epdconfig.send_command(0X10) # DEEP_SLEEP_MODE
+        epdconfig.send_data(0x01)
 
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in66b.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in66b.py
@@ -36,36 +36,9 @@ EPD_HEIGHT      = 296
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
-
 
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -78,20 +51,20 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(30)
         self.ReadBusy()
 
-        self.send_command(0x11) # setting gaet number
-        self.send_data(0x03)
+        epdconfig.send_command(0x11) # setting gaet number
+        epdconfig.send_data(0x03)
         
         self.setWindows(0, 0, self.width-1, self.height-1)
         
-        self.send_command(0x21)
-        self.send_data(0x00)
-        self.send_data(0x80)
+        epdconfig.send_command(0x21)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x80)
         
         self.setCursor(0, 0)
         self.ReadBusy()
@@ -99,26 +72,26 @@ class EPD:
         return 0
 
     def setWindows(self, Xstart, Ystart, Xend, Yend):
-        self.send_command(0x44); # SET_RAM_X_ADDRESS_START_END_POSITION
-        self.send_data((Xstart>>3) & 0x1F);
-        self.send_data((Xend>>3) & 0x1F);
+        epdconfig.send_command(0x44); # SET_RAM_X_ADDRESS_START_END_POSITION
+        epdconfig.send_data((Xstart>>3) & 0x1F);
+        epdconfig.send_data((Xend>>3) & 0x1F);
         
-        self.send_command(0x45); # SET_RAM_Y_ADDRESS_START_END_POSITION
-        self.send_data(Ystart & 0xFF);
-        self.send_data((Ystart >> 8) & 0x01);
-        self.send_data(Yend & 0xFF);
-        self.send_data((Yend >> 8) & 0x01);
+        epdconfig.send_command(0x45); # SET_RAM_Y_ADDRESS_START_END_POSITION
+        epdconfig.send_data(Ystart & 0xFF);
+        epdconfig.send_data((Ystart >> 8) & 0x01);
+        epdconfig.send_data(Yend & 0xFF);
+        epdconfig.send_data((Yend >> 8) & 0x01);
 
     def setCursor(self, Xstart, Ystart):
-        self.send_command(0x4E); # SET_RAM_X_ADDRESS_COUNTER
-        self.send_data(Xstart & 0x1F);
+        epdconfig.send_command(0x4E); # SET_RAM_X_ADDRESS_COUNTER
+        epdconfig.send_data(Xstart & 0x1F);
 
-        self.send_command(0x4F); # SET_RAM_Y_ADDRESS_COUNTER
-        self.send_data(Ystart & 0xFF);
-        self.send_data((Ystart >> 8) & 0x01);
+        epdconfig.send_command(0x4F); # SET_RAM_Y_ADDRESS_COUNTER
+        epdconfig.send_data(Ystart & 0xFF);
+        epdconfig.send_data((Ystart >> 8) & 0x01);
         
     def turnon_display(self):
-        self.send_command(0x20)
+        epdconfig.send_command(0x20)
         self.ReadBusy()
 
     def getbuffer(self, image):
@@ -149,43 +122,43 @@ class EPD:
         if (Blackimage == None or Redimage == None):
             return            
 
-        self.send_command(0x4E)
-        self.send_data(0x01)
-        self.send_command(0x4F)
-        self.send_data(0x27)
-        self.send_data(0x01)
+        epdconfig.send_command(0x4E)
+        epdconfig.send_data(0x01)
+        epdconfig.send_command(0x4F)
+        epdconfig.send_data(0x27)
+        epdconfig.send_data(0x01)
 
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(Blackimage[i + j * int(self.width / 8)])   
+                epdconfig.send_data(Blackimage[i + j * int(self.width / 8)])   
 
-        self.send_command(0x26)
+        epdconfig.send_command(0x26)
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(~Redimage[i + j * int(self.width / 8)]) 
+                epdconfig.send_data(~Redimage[i + j * int(self.width / 8)]) 
                 
         self.turnon_display()
         
 
     def Clear(self):
 
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(0xff)   
+                epdconfig.send_data(0xff)   
 
-        self.send_command(0x26)
+        epdconfig.send_command(0x26)
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(0x00) 
+                epdconfig.send_data(0x00) 
 
         self.turnon_display()
 
 
     def sleep(self):
-        self.send_command(0X10) # DEEP_SLEEP_MODE
-        self.send_data(0x01)
+        epdconfig.send_command(0X10) # DEEP_SLEEP_MODE
+        epdconfig.send_data(0x01)
 
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7.py
@@ -40,10 +40,7 @@ GRAY3  = 0x80 #gray
 GRAY4  = 0x00 #Blackest
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
         self.GRAY1  = GRAY1 #white
@@ -148,27 +145,6 @@ class EPD:
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     ]
-    
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):        
         logging.debug("e-Paper busy")
@@ -177,188 +153,188 @@ class EPD:
         logging.debug("e-Paper busy release")
 
     def set_lut(self):
-        self.send_command(0x20) # vcom
+        epdconfig.send_command(0x20) # vcom
         for count in range(0, 44):
-            self.send_data(self.lut_vcom_dc[count])
-        self.send_command(0x21) # ww --
+            epdconfig.send_data(self.lut_vcom_dc[count])
+        epdconfig.send_command(0x21) # ww --
         for count in range(0, 42):
-            self.send_data(self.lut_ww[count])
-        self.send_command(0x22) # bw r
+            epdconfig.send_data(self.lut_ww[count])
+        epdconfig.send_command(0x22) # bw r
         for count in range(0, 42):
-            self.send_data(self.lut_bw[count])
-        self.send_command(0x23) # wb w
+            epdconfig.send_data(self.lut_bw[count])
+        epdconfig.send_command(0x23) # wb w
         for count in range(0, 42):
-            self.send_data(self.lut_bb[count])
-        self.send_command(0x24) # bb b
+            epdconfig.send_data(self.lut_bb[count])
+        epdconfig.send_command(0x24) # bb b
         for count in range(0, 42):
-            self.send_data(self.lut_wb[count])
+            epdconfig.send_data(self.lut_wb[count])
             
     def gray_SetLut(self):
-        self.send_command(0x20)
+        epdconfig.send_command(0x20)
         for count in range(0, 44):        #vcom
-            self.send_data(self.gray_lut_vcom[count])
+            epdconfig.send_data(self.gray_lut_vcom[count])
             
-        self.send_command(0x21)							#red not use
+        epdconfig.send_command(0x21)							#red not use
         for count in range(0, 42): 
-            self.send_data(self.gray_lut_ww[count])
+            epdconfig.send_data(self.gray_lut_ww[count])
 
-        self.send_command(0x22)							#bw r
+        epdconfig.send_command(0x22)							#bw r
         for count in range(0, 42): 
-            self.send_data(self.gray_lut_bw[count])
+            epdconfig.send_data(self.gray_lut_bw[count])
 
-        self.send_command(0x23)							#wb w
+        epdconfig.send_command(0x23)							#wb w
         for count in range(0, 42): 
-            self.send_data(self.gray_lut_wb[count])
+            epdconfig.send_data(self.gray_lut_wb[count])
 
-        self.send_command(0x24)							#bb b
+        epdconfig.send_command(0x24)							#bb b
         for count in range(0, 42): 
-            self.send_data(self.gray_lut_bb[count])
+            epdconfig.send_data(self.gray_lut_bb[count])
 
-        self.send_command(0x25)							#vcom
+        epdconfig.send_command(0x25)							#vcom
         for count in range(0, 42): 
-            self.send_data(self.gray_lut_ww[count])
+            epdconfig.send_data(self.gray_lut_ww[count])
     
     def init(self):
         if (epdconfig.module_init() != 0):
             return -1
             
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
-        self.send_command(0x01) # POWER_SETTING
-        self.send_data(0x03) # VDS_EN, VDG_EN
-        self.send_data(0x00) # VCOM_HV, VGHL_LV[1], VGHL_LV[0]
-        self.send_data(0x2b) # VDH
-        self.send_data(0x2b) # VDL
-        self.send_data(0x09) # VDHR
+        epdconfig.send_command(0x01) # POWER_SETTING
+        epdconfig.send_data(0x03) # VDS_EN, VDG_EN
+        epdconfig.send_data(0x00) # VCOM_HV, VGHL_LV[1], VGHL_LV[0]
+        epdconfig.send_data(0x2b) # VDH
+        epdconfig.send_data(0x2b) # VDL
+        epdconfig.send_data(0x09) # VDHR
         
-        self.send_command(0x06) # BOOSTER_SOFT_START
-        self.send_data(0x07)
-        self.send_data(0x07)
-        self.send_data(0x17)
-        
-        # Power optimization
-        self.send_command(0xF8)
-        self.send_data(0x60)
-        self.send_data(0xA5)
+        epdconfig.send_command(0x06) # BOOSTER_SOFT_START
+        epdconfig.send_data(0x07)
+        epdconfig.send_data(0x07)
+        epdconfig.send_data(0x17)
         
         # Power optimization
-        self.send_command(0xF8)
-        self.send_data(0x89)
-        self.send_data(0xA5)
+        epdconfig.send_command(0xF8)
+        epdconfig.send_data(0x60)
+        epdconfig.send_data(0xA5)
         
         # Power optimization
-        self.send_command(0xF8)
-        self.send_data(0x90)
-        self.send_data(0x00)
+        epdconfig.send_command(0xF8)
+        epdconfig.send_data(0x89)
+        epdconfig.send_data(0xA5)
         
         # Power optimization
-        self.send_command(0xF8)
-        self.send_data(0x93)
-        self.send_data(0x2A)
+        epdconfig.send_command(0xF8)
+        epdconfig.send_data(0x90)
+        epdconfig.send_data(0x00)
         
         # Power optimization
-        self.send_command(0xF8)
-        self.send_data(0xA0)
-        self.send_data(0xA5)
+        epdconfig.send_command(0xF8)
+        epdconfig.send_data(0x93)
+        epdconfig.send_data(0x2A)
         
         # Power optimization
-        self.send_command(0xF8)
-        self.send_data(0xA1)
-        self.send_data(0x00)
+        epdconfig.send_command(0xF8)
+        epdconfig.send_data(0xA0)
+        epdconfig.send_data(0xA5)
         
         # Power optimization
-        self.send_command(0xF8)
-        self.send_data(0x73)
-        self.send_data(0x41)
+        epdconfig.send_command(0xF8)
+        epdconfig.send_data(0xA1)
+        epdconfig.send_data(0x00)
         
-        self.send_command(0x16) # PARTIAL_DISPLAY_REFRESH
-        self.send_data(0x00)
-        self.send_command(0x04) # POWER_ON
+        # Power optimization
+        epdconfig.send_command(0xF8)
+        epdconfig.send_data(0x73)
+        epdconfig.send_data(0x41)
+        
+        epdconfig.send_command(0x16) # PARTIAL_DISPLAY_REFRESH
+        epdconfig.send_data(0x00)
+        epdconfig.send_command(0x04) # POWER_ON
         self.ReadBusy()
 
-        self.send_command(0x00) # PANEL_SETTING
-        self.send_data(0xAF) # KW-BF   KWR-AF    BWROTP 0f
+        epdconfig.send_command(0x00) # PANEL_SETTING
+        epdconfig.send_data(0xAF) # KW-BF   KWR-AF    BWROTP 0f
         
-        self.send_command(0x30) # PLL_CONTROL
-        self.send_data(0x3A) # 3A 100HZ   29 150Hz 39 200HZ    31 171HZ
+        epdconfig.send_command(0x30) # PLL_CONTROL
+        epdconfig.send_data(0x3A) # 3A 100HZ   29 150Hz 39 200HZ    31 171HZ
     
-        self.send_command(0X50)			#VCOM AND DATA INTERVAL SETTING			
-        self.send_data(0x57)
+        epdconfig.send_command(0X50)			#VCOM AND DATA INTERVAL SETTING			
+        epdconfig.send_data(0x57)
         
-        self.send_command(0x82) # VCM_DC_SETTING_REGISTER
-        self.send_data(0x12)
+        epdconfig.send_command(0x82) # VCM_DC_SETTING_REGISTER
+        epdconfig.send_data(0x12)
         self.set_lut()
         return 0
 
     def Init_4Gray(self):
         if (epdconfig.module_init() != 0):
             return -1
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
-        self.send_command(0x01)			#POWER SETTING
-        self.send_data (0x03)
-        self.send_data (0x00)    
-        self.send_data (0x2b)															 
-        self.send_data (0x2b)		
+        epdconfig.send_command(0x01)			#POWER SETTING
+        epdconfig.send_data (0x03)
+        epdconfig.send_data (0x00)    
+        epdconfig.send_data (0x2b)															 
+        epdconfig.send_data (0x2b)		
 
 
-        self.send_command(0x06)         #booster soft start
-        self.send_data (0x07)		#A
-        self.send_data (0x07)		#B
-        self.send_data (0x17)		#C 
+        epdconfig.send_command(0x06)         #booster soft start
+        epdconfig.send_data (0x07)		#A
+        epdconfig.send_data (0x07)		#B
+        epdconfig.send_data (0x17)		#C 
 
-        self.send_command(0xF8)         #boost??
-        self.send_data (0x60)
-        self.send_data (0xA5)
+        epdconfig.send_command(0xF8)         #boost??
+        epdconfig.send_data (0x60)
+        epdconfig.send_data (0xA5)
 
-        self.send_command(0xF8)         #boost??
-        self.send_data (0x89)
-        self.send_data (0xA5)
+        epdconfig.send_command(0xF8)         #boost??
+        epdconfig.send_data (0x89)
+        epdconfig.send_data (0xA5)
 
-        self.send_command(0xF8)         #boost??
-        self.send_data (0x90)
-        self.send_data (0x00)
+        epdconfig.send_command(0xF8)         #boost??
+        epdconfig.send_data (0x90)
+        epdconfig.send_data (0x00)
 
-        self.send_command(0xF8)         #boost??
-        self.send_data (0x93)
-        self.send_data (0x2A)
+        epdconfig.send_command(0xF8)         #boost??
+        epdconfig.send_data (0x93)
+        epdconfig.send_data (0x2A)
 
-        self.send_command(0xF8)         #boost??
-        self.send_data (0xa0)
-        self.send_data (0xa5)
+        epdconfig.send_command(0xF8)         #boost??
+        epdconfig.send_data (0xa0)
+        epdconfig.send_data (0xa5)
 
-        self.send_command(0xF8)         #boost??
-        self.send_data (0xa1)
-        self.send_data (0x00)
+        epdconfig.send_command(0xF8)         #boost??
+        epdconfig.send_data (0xa1)
+        epdconfig.send_data (0x00)
 
-        self.send_command(0xF8)         #boost??
-        self.send_data (0x73)
-        self.send_data (0x41)
+        epdconfig.send_command(0xF8)         #boost??
+        epdconfig.send_data (0x73)
+        epdconfig.send_data (0x41)
 
-        self.send_command(0x16)
-        self.send_data(0x00)	
+        epdconfig.send_command(0x16)
+        epdconfig.send_data(0x00)	
 
-        self.send_command(0x04)
+        epdconfig.send_command(0x04)
         self.ReadBusy()
 
-        self.send_command(0x00)			#panel setting
-        self.send_data(0xbf)		#KW-BF   KWR-AF	BWROTP 0f
+        epdconfig.send_command(0x00)			#panel setting
+        epdconfig.send_data(0xbf)		#KW-BF   KWR-AF	BWROTP 0f
 
-        self.send_command(0x30)			#PLL setting
-        self.send_data (0x90)      	#100hz 
+        epdconfig.send_command(0x30)			#PLL setting
+        epdconfig.send_data (0x90)      	#100hz 
 
-        self.send_command(0x61)			#resolution setting
-        self.send_data (0x00)		#176
-        self.send_data (0xb0)     	 
-        self.send_data (0x01)		#264
-        self.send_data (0x08)
+        epdconfig.send_command(0x61)			#resolution setting
+        epdconfig.send_data (0x00)		#176
+        epdconfig.send_data (0xb0)     	 
+        epdconfig.send_data (0x01)		#264
+        epdconfig.send_data (0x08)
 
-        self.send_command(0x82)			#vcom_DC setting
-        self.send_data (0x12)
+        epdconfig.send_command(0x82)			#vcom_DC setting
+        epdconfig.send_data (0x12)
 
-        self.send_command(0X50)			#VCOM AND DATA INTERVAL SETTING			
-        self.send_data(0x57)
+        epdconfig.send_command(0X50)			#VCOM AND DATA INTERVAL SETTING			
+        epdconfig.send_data(0x57)
 
     def getbuffer(self, image):
         # logging.debug("bufsiz = ",int(self.width/8) * self.height)
@@ -421,17 +397,17 @@ class EPD:
         return buf
     
     def display(self, image):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
-        self.send_command(0x13)
+            epdconfig.send_data(0xFF)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(image[i])
-        self.send_command(0x12) 
+            epdconfig.send_data(image[i])
+        epdconfig.send_command(0x12) 
         self.ReadBusy()
 
     def display_4Gray(self, image):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, 5808):                     #5808*4  46464
             temp3=0
             for j in range(0, 2):
@@ -461,9 +437,9 @@ class EPD:
                     if(j!=1 or k!=1):				
                         temp3 <<= 1
                     temp1 <<= 2
-            self.send_data(temp3)
+            epdconfig.send_data(temp3)
             
-        self.send_command(0x13)	       
+        epdconfig.send_command(0x13)	       
         for i in range(0, 5808):                #5808*4  46464
             temp3=0
             for j in range(0, 2):
@@ -493,30 +469,30 @@ class EPD:
                     if(j!=1 or k!=1):					
                         temp3 <<= 1
                     temp1 <<= 2
-            self.send_data(temp3)
+            epdconfig.send_data(temp3)
         
         self.gray_SetLut()
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(200)
         self.ReadBusy()
         # pass
         
     def Clear(self, color):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
-        self.send_command(0x13)
+            epdconfig.send_data(0xFF)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
-        self.send_command(0x12) 
+            epdconfig.send_data(0xFF)
+        epdconfig.send_command(0x12) 
         self.ReadBusy()
 
     def sleep(self):
-        self.send_command(0X50)
-        self.send_data(0xf7)
-        self.send_command(0X02)
-        self.send_command(0X07)
-        self.send_data(0xA5)
+        epdconfig.send_command(0X50)
+        epdconfig.send_data(0xf7)
+        epdconfig.send_command(0X02)
+        epdconfig.send_command(0X07)
+        epdconfig.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7b.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7b.py
@@ -37,10 +37,7 @@ EPD_HEIGHT      = 264
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
 
@@ -95,28 +92,7 @@ class EPD:
         0x00, 0x04, 0x10, 0x00, 0x00, 0x05,
         0x00, 0x03, 0x0E, 0x00, 0x00, 0x0A,
         0x00, 0x23, 0x00, 0x00, 0x00, 0x01
-    ]
-
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(2)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
+    ] 
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -125,83 +101,83 @@ class EPD:
         logging.debug("e-Paper busy release")
         
     def set_lut(self):
-        self.send_command(0x20)               # vcom
+        epdconfig.send_command(0x20)               # vcom
         for count in range(0, 44):
-            self.send_data(self.lut_vcom_dc[count])
-        self.send_command(0x21)         # ww --
+            epdconfig.send_data(self.lut_vcom_dc[count])
+        epdconfig.send_command(0x21)         # ww --
         for count in range(0, 42):
-            self.send_data(self.lut_ww[count])
-        self.send_command(0x22)         # bw r
+            epdconfig.send_data(self.lut_ww[count])
+        epdconfig.send_command(0x22)         # bw r
         for count in range(0, 42):
-            self.send_data(self.lut_bw[count])
-        self.send_command(0x23)         # wb w
+            epdconfig.send_data(self.lut_bw[count])
+        epdconfig.send_command(0x23)         # wb w
         for count in range(0, 42):
-            self.send_data(self.lut_bb[count])
-        self.send_command(0x24)         # bb b
+            epdconfig.send_data(self.lut_bb[count])
+        epdconfig.send_command(0x24)         # bb b
         for count in range(0, 42):
-            self.send_data(self.lut_wb[count])
+            epdconfig.send_data(self.lut_wb[count])
             
     def init(self):
         if (epdconfig.module_init() != 0):
             return -1
             
-        self.reset()
+        epdconfig.reset(200, 2, 200)
 
-        self.send_command(0x04) # POWER_ON
+        epdconfig.send_command(0x04) # POWER_ON
         self.ReadBusy()
 
-        self.send_command(0x00) # PANEL_SETTING
-        self.send_data(0xaf) #KW-BF   KWR-AF    BWROTP 0f
+        epdconfig.send_command(0x00) # PANEL_SETTING
+        epdconfig.send_data(0xaf) #KW-BF   KWR-AF    BWROTP 0f
         
-        self.send_command(0x30) # PLL_CONTROL
-        self.send_data(0x3a) #3A 100HZ   29 150Hz 39 200HZ    31 171HZ
+        epdconfig.send_command(0x30) # PLL_CONTROL
+        epdconfig.send_data(0x3a) #3A 100HZ   29 150Hz 39 200HZ    31 171HZ
 
-        self.send_command(0x01) # POWER_SETTING
-        self.send_data(0x03) # VDS_EN, VDG_EN
-        self.send_data(0x00) # VCOM_HV, VGHL_LV[1], VGHL_LV[0]
-        self.send_data(0x2b) # VDH
-        self.send_data(0x2b) # VDL
-        self.send_data(0x09) # VDHR
+        epdconfig.send_command(0x01) # POWER_SETTING
+        epdconfig.send_data(0x03) # VDS_EN, VDG_EN
+        epdconfig.send_data(0x00) # VCOM_HV, VGHL_LV[1], VGHL_LV[0]
+        epdconfig.send_data(0x2b) # VDH
+        epdconfig.send_data(0x2b) # VDL
+        epdconfig.send_data(0x09) # VDHR
 
-        self.send_command(0x06) # BOOSTER_SOFT_START
-        self.send_data(0x07)
-        self.send_data(0x07)
-        self.send_data(0x17)
-
-        # Power optimization
-        self.send_command(0xF8)
-        self.send_data(0x60)
-        self.send_data(0xA5)
+        epdconfig.send_command(0x06) # BOOSTER_SOFT_START
+        epdconfig.send_data(0x07)
+        epdconfig.send_data(0x07)
+        epdconfig.send_data(0x17)
 
         # Power optimization
-        self.send_command(0xF8)
-        self.send_data(0x89)
-        self.send_data(0xA5)
+        epdconfig.send_command(0xF8)
+        epdconfig.send_data(0x60)
+        epdconfig.send_data(0xA5)
 
         # Power optimization
-        self.send_command(0xF8)
-        self.send_data(0x90)
-        self.send_data(0x00)
+        epdconfig.send_command(0xF8)
+        epdconfig.send_data(0x89)
+        epdconfig.send_data(0xA5)
+
+        # Power optimization
+        epdconfig.send_command(0xF8)
+        epdconfig.send_data(0x90)
+        epdconfig.send_data(0x00)
         
         # Power optimization
-        self.send_command(0xF8)
-        self.send_data(0x93)
-        self.send_data(0x2A)
+        epdconfig.send_command(0xF8)
+        epdconfig.send_data(0x93)
+        epdconfig.send_data(0x2A)
 
         # Power optimization
-        self.send_command(0xF8)
-        self.send_data(0x73)
-        self.send_data(0x41)
+        epdconfig.send_command(0xF8)
+        epdconfig.send_data(0x73)
+        epdconfig.send_data(0x41)
 
-        self.send_command(0x82) # VCM_DC_SETTING_REGISTER
-        self.send_data(0x12)                   
-        self.send_command(0x50) # VCOM_AND_DATA_INTERVAL_SETTING
-        self.send_data(0x87) # define by OTP
+        epdconfig.send_command(0x82) # VCM_DC_SETTING_REGISTER
+        epdconfig.send_data(0x12)                   
+        epdconfig.send_command(0x50) # VCOM_AND_DATA_INTERVAL_SETTING
+        epdconfig.send_data(0x87) # define by OTP
 
         self.set_lut()
 
-        self.send_command(0x16) # PARTIAL_DISPLAY_REFRESH
-        self.send_data(0x00)
+        epdconfig.send_command(0x16) # PARTIAL_DISPLAY_REFRESH
+        epdconfig.send_data(0x00)
         
         return 0
 
@@ -230,39 +206,39 @@ class EPD:
         return buf
 
     def display(self, imageblack, imagered):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(~imageblack[i])
-        self.send_command(0x11)
+            epdconfig.send_data(~imageblack[i])
+        epdconfig.send_command(0x11)
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(~imagered[i])
-        self.send_command(0x11)
+            epdconfig.send_data(~imagered[i])
+        epdconfig.send_command(0x11)
         
-        self.send_command(0x12) 
+        epdconfig.send_command(0x12) 
         self.ReadBusy()
         
     def Clear(self):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
-        self.send_command(0x11) 
+            epdconfig.send_data(0x00)
+        epdconfig.send_command(0x11) 
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
-        self.send_command(0x11)
+            epdconfig.send_data(0x00)
+        epdconfig.send_command(0x11)
         
-        self.send_command(0x12) 
+        epdconfig.send_command(0x12) 
         self.ReadBusy()
 
     def sleep(self):
-        self.send_command(0X50)
-        self.send_data(0xf7)
-        self.send_command(0X02)
-        self.send_command(0X07)
-        self.send_data(0xA5)
+        epdconfig.send_command(0X50)
+        epdconfig.send_data(0xf7)
+        epdconfig.send_command(0X02)
+        epdconfig.send_command(0X07)
+        epdconfig.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7b_V2.py
@@ -37,36 +37,10 @@ EPD_HEIGHT      = 264
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
-
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(2)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    # Send Command
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    # Send Data
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
-        
+    
     # Read Busy
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -76,42 +50,42 @@ class EPD:
             
     # Setting the display window
     def SetWindows(self, Xstart, Ystart, Xend, Yend):
-        self.send_command(0x44)
-        self.send_data((Xstart >> 3) & 0xff)
-        self.send_data((Xend >> 3) & 0xff)
+        epdconfig.send_command(0x44)
+        epdconfig.send_data((Xstart >> 3) & 0xff)
+        epdconfig.send_data((Xend >> 3) & 0xff)
         
-        self.send_command(0x45)
-        self.send_data(Ystart & 0xff)
-        self.send_data((Ystart >> 8) & 0xff)
-        self.send_data(Yend & 0xff)
-        self.send_data((Yend >> 8) & 0xff)
+        epdconfig.send_command(0x45)
+        epdconfig.send_data(Ystart & 0xff)
+        epdconfig.send_data((Ystart >> 8) & 0xff)
+        epdconfig.send_data(Yend & 0xff)
+        epdconfig.send_data((Yend >> 8) & 0xff)
     
     # Set Cursor
     def SetCursor(self, Xstart, Ystart):
-        self.send_command(0x4E)
-        self.send_data(Xstart & 0xff)
-        self.send_command(0x4F)
-        self.send_data(Ystart & 0xff)
-        self.send_data((Ystart >> 8) & 0xff)
+        epdconfig.send_command(0x4E)
+        epdconfig.send_data(Xstart & 0xff)
+        epdconfig.send_command(0x4F)
+        epdconfig.send_data(Ystart & 0xff)
+        epdconfig.send_data((Ystart >> 8) & 0xff)
         
     # Initialize the e-Paper register
     def init(self):
         if (epdconfig.module_init() != 0):
             return -1
             
-        self.reset()
+        epdconfig.reset(200, 2, 200)
 
         self.ReadBusy() 
-        self.send_command(0x12)      
+        epdconfig.send_command(0x12)      
         self.ReadBusy() 
         
-        self.send_command(0x00)     
-        self.send_data(0x27) 
-        self.send_data(0x01) 
-        self.send_data(0x00) 
+        epdconfig.send_command(0x00)     
+        epdconfig.send_data(0x27) 
+        epdconfig.send_data(0x01) 
+        epdconfig.send_data(0x00) 
         
-        self.send_command(0x11)     
-        self.send_data(0x03) 
+        epdconfig.send_command(0x11)     
+        epdconfig.send_data(0x03) 
         
         self.SetWindows(0, 0, self.width-1, self.height-1)
         self.SetCursor(0, 0)
@@ -146,37 +120,37 @@ class EPD:
         Width = self.width / 8 
         Height = self.height 
 
-        self.send_command(0x24) 
+        epdconfig.send_command(0x24) 
         for i in range(0, int(Width * Height)):
-            self.send_data(imageblack[i]) 
+            epdconfig.send_data(imageblack[i]) 
 
-        self.send_command(0x26) 
+        epdconfig.send_command(0x26) 
         for i in range(0, int(Width * Height)):
-            self.send_data(~imagered[i]) 
+            epdconfig.send_data(~imagered[i]) 
         
         self.TurnOnDisplay()
 
     # Clear the screen
     def Clear(self):
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xff)
+            epdconfig.send_data(0xff)
 
-        self.send_command(0x26)
+        epdconfig.send_command(0x26)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
+            epdconfig.send_data(0x00)
             
         self.TurnOnDisplay()
         
     # Turn on display
     def TurnOnDisplay(self):
-        self.send_command(0x20)
+        epdconfig.send_command(0x20)
         self.ReadBusy()
 
     # Enter sleep mode
     def sleep(self):
-        self.send_command(0x10)
-        self.send_data(0x01)
+        epdconfig.send_command(0x10)
+        epdconfig.send_data(0x01)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9.py
@@ -36,10 +36,7 @@ EPD_HEIGHT      = 296
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
 
@@ -57,94 +54,73 @@ class EPD:
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x13, 0x14, 0x44, 0x12,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-    ]
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
+    ] 
         
     def ReadBusy(self):
         while(epdconfig.digital_read(self.busy_pin) == 1):      #  0: idle, 1: busy
             epdconfig.delay_ms(200) 
 
     def TurnOnDisplay(self):
-        self.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
-        self.send_data(0xC4)
-        self.send_command(0x20) # MASTER_ACTIVATION
-        self.send_command(0xFF) # TERMINATE_FRAME_READ_WRITE
+        epdconfig.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
+        epdconfig.send_data(0xC4)
+        epdconfig.send_command(0x20) # MASTER_ACTIVATION
+        epdconfig.send_command(0xFF) # TERMINATE_FRAME_READ_WRITE
         
         logging.debug("e-Paper busy")
         self.ReadBusy()
         logging.debug("e-Paper busy release")  
 
     def SetWindow(self, x_start, y_start, x_end, y_end):
-        self.send_command(0x44) # SET_RAM_X_ADDRESS_START_END_POSITION
+        epdconfig.send_command(0x44) # SET_RAM_X_ADDRESS_START_END_POSITION
         # x point must be the multiple of 8 or the last 3 bits will be ignored
-        self.send_data((x_start >> 3) & 0xFF)
-        self.send_data((x_end >> 3) & 0xFF)
-        self.send_command(0x45) # SET_RAM_Y_ADDRESS_START_END_POSITION
-        self.send_data(y_start & 0xFF)
-        self.send_data((y_start >> 8) & 0xFF)
-        self.send_data(y_end & 0xFF)
-        self.send_data((y_end >> 8) & 0xFF)
+        epdconfig.send_data((x_start >> 3) & 0xFF)
+        epdconfig.send_data((x_end >> 3) & 0xFF)
+        epdconfig.send_command(0x45) # SET_RAM_Y_ADDRESS_START_END_POSITION
+        epdconfig.send_data(y_start & 0xFF)
+        epdconfig.send_data((y_start >> 8) & 0xFF)
+        epdconfig.send_data(y_end & 0xFF)
+        epdconfig.send_data((y_end >> 8) & 0xFF)
 
     def SetCursor(self, x, y):
-        self.send_command(0x4E) # SET_RAM_X_ADDRESS_COUNTER
+        epdconfig.send_command(0x4E) # SET_RAM_X_ADDRESS_COUNTER
         # x point must be the multiple of 8 or the last 3 bits will be ignored
-        self.send_data((x >> 3) & 0xFF)
-        self.send_command(0x4F) # SET_RAM_Y_ADDRESS_COUNTER
-        self.send_data(y & 0xFF)
-        self.send_data((y >> 8) & 0xFF)
+        epdconfig.send_data((x >> 3) & 0xFF)
+        epdconfig.send_command(0x4F) # SET_RAM_Y_ADDRESS_COUNTER
+        epdconfig.send_data(y & 0xFF)
+        epdconfig.send_data((y >> 8) & 0xFF)
         self.ReadBusy()
         
     def init(self, lut):
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
-        self.send_command(0x01) # DRIVER_OUTPUT_CONTROL
-        self.send_data((EPD_HEIGHT - 1) & 0xFF)
-        self.send_data(((EPD_HEIGHT - 1) >> 8) & 0xFF)
-        self.send_data(0x00) # GD = 0 SM = 0 TB = 0
+        epdconfig.send_command(0x01) # DRIVER_OUTPUT_CONTROL
+        epdconfig.send_data((EPD_HEIGHT - 1) & 0xFF)
+        epdconfig.send_data(((EPD_HEIGHT - 1) >> 8) & 0xFF)
+        epdconfig.send_data(0x00) # GD = 0 SM = 0 TB = 0
         
-        self.send_command(0x0C) # BOOSTER_SOFT_START_CONTROL 
-        self.send_data(0xD7)
-        self.send_data(0xD6)
-        self.send_data(0x9D)
+        epdconfig.send_command(0x0C) # BOOSTER_SOFT_START_CONTROL 
+        epdconfig.send_data(0xD7)
+        epdconfig.send_data(0xD6)
+        epdconfig.send_data(0x9D)
         
-        self.send_command(0x2C) # WRITE_VCOM_REGISTER
-        self.send_data(0xA8) # VCOM 7C
+        epdconfig.send_command(0x2C) # WRITE_VCOM_REGISTER
+        epdconfig.send_data(0xA8) # VCOM 7C
         
-        self.send_command(0x3A) # SET_DUMMY_LINE_PERIOD
-        self.send_data(0x1A) # 4 dummy lines per gate
+        epdconfig.send_command(0x3A) # SET_DUMMY_LINE_PERIOD
+        epdconfig.send_data(0x1A) # 4 dummy lines per gate
         
-        self.send_command(0x3B) # SET_GATE_TIME
-        self.send_data(0x08) # 2us per line
+        epdconfig.send_command(0x3B) # SET_GATE_TIME
+        epdconfig.send_data(0x08) # 2us per line
         
-        self.send_command(0x11) # DATA_ENTRY_MODE_SETTING
-        self.send_data(0x03) # X increment Y increment
+        epdconfig.send_command(0x11) # DATA_ENTRY_MODE_SETTING
+        epdconfig.send_data(0x03) # X increment Y increment
         
-        self.send_command(0x32) # WRITE_LUT_REGISTER
+        epdconfig.send_command(0x32) # WRITE_LUT_REGISTER
         for i in range(0, len(lut)):
-            self.send_data(lut[i])
+            epdconfig.send_data(lut[i])
         # EPD hardware init end
         return 0
 
@@ -178,23 +154,23 @@ class EPD:
         self.SetWindow(0, 0, self.width - 1, self.height - 1)
         for j in range(0, self.height):
             self.SetCursor(0, j)
-            self.send_command(0x24) # WRITE_RAM
+            epdconfig.send_command(0x24) # WRITE_RAM
             for i in range(0, int(self.width / 8)):
-                self.send_data(image[i + j * int(self.width / 8)])   
+                epdconfig.send_data(image[i + j * int(self.width / 8)])   
         self.TurnOnDisplay()
         
     def Clear(self, color):
         self.SetWindow(0, 0, self.width - 1, self.height - 1)
         for j in range(0, self.height):
             self.SetCursor(0, j)
-            self.send_command(0x24) # WRITE_RAM
+            epdconfig.send_command(0x24) # WRITE_RAM
             for i in range(0, int(self.width / 8)):
-                self.send_data(color)   
+                epdconfig.send_data(color)   
         self.TurnOnDisplay()
 
     def sleep(self):
-        self.send_command(0x10) # DEEP_SLEEP_MODE
-        self.send_data(0x01)
+        epdconfig.send_command(0x10) # DEEP_SLEEP_MODE
+        epdconfig.send_data(0x01)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9_V2.py
@@ -36,10 +36,7 @@ EPD_HEIGHT      = 296
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
         
@@ -63,28 +60,7 @@ class EPD:
         0x0,0x0,0x0,0x0,0x0,0x0,0x0,
         0x22,0x22,0x22,0x22,0x22,0x22,0x0,0x0,0x0,
         0x22,0x17,0x41,0xB0,0x32,0x36,
-    ]
-
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(50) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(2)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(50)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
+    ] 
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -93,67 +69,67 @@ class EPD:
         logging.debug("e-Paper busy release")  
 
     def TurnOnDisplay(self):
-        self.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
-        self.send_data(0xF7)
-        self.send_command(0x20) # MASTER_ACTIVATION
+        epdconfig.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
+        epdconfig.send_data(0xF7)
+        epdconfig.send_command(0x20) # MASTER_ACTIVATION
         self.ReadBusy()
 
     def TurnOnDisplay_Partial(self):
-        self.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
-        self.send_data(0x0F)
-        self.send_command(0x20) # MASTER_ACTIVATION
+        epdconfig.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
+        epdconfig.send_data(0x0F)
+        epdconfig.send_command(0x20) # MASTER_ACTIVATION
         self.ReadBusy()
 
     def SendLut(self):
-        self.send_command(0x32)
+        epdconfig.send_command(0x32)
         for i in range(0, 153):
-            self.send_data(self.WF_PARTIAL_2IN9[i])
+            epdconfig.send_data(self.WF_PARTIAL_2IN9[i])
         self.ReadBusy()
 
     def SetWindow(self, x_start, y_start, x_end, y_end):
-        self.send_command(0x44) # SET_RAM_X_ADDRESS_START_END_POSITION
+        epdconfig.send_command(0x44) # SET_RAM_X_ADDRESS_START_END_POSITION
         # x point must be the multiple of 8 or the last 3 bits will be ignored
-        self.send_data((x_start>>3) & 0xFF)
-        self.send_data((x_end>>3) & 0xFF)
-        self.send_command(0x45) # SET_RAM_Y_ADDRESS_START_END_POSITION
-        self.send_data(y_start & 0xFF)
-        self.send_data((y_start >> 8) & 0xFF)
-        self.send_data(y_end & 0xFF)
-        self.send_data((y_end >> 8) & 0xFF)
+        epdconfig.send_data((x_start>>3) & 0xFF)
+        epdconfig.send_data((x_end>>3) & 0xFF)
+        epdconfig.send_command(0x45) # SET_RAM_Y_ADDRESS_START_END_POSITION
+        epdconfig.send_data(y_start & 0xFF)
+        epdconfig.send_data((y_start >> 8) & 0xFF)
+        epdconfig.send_data(y_end & 0xFF)
+        epdconfig.send_data((y_end >> 8) & 0xFF)
 
     def SetCursor(self, x, y):
-        self.send_command(0x4E) # SET_RAM_X_ADDRESS_COUNTER
+        epdconfig.send_command(0x4E) # SET_RAM_X_ADDRESS_COUNTER
         # x point must be the multiple of 8 or the last 3 bits will be ignored
-        self.send_data(x & 0xFF)
+        epdconfig.send_data(x & 0xFF)
         
-        self.send_command(0x4F) # SET_RAM_Y_ADDRESS_COUNTER
-        self.send_data(y & 0xFF)
-        self.send_data((y >> 8) & 0xFF)
+        epdconfig.send_command(0x4F) # SET_RAM_Y_ADDRESS_COUNTER
+        epdconfig.send_data(y & 0xFF)
+        epdconfig.send_data((y >> 8) & 0xFF)
         self.ReadBusy()
         
     def init(self):
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start     
-        self.reset()
+        epdconfig.reset(50, 2, 50)
 
         self.ReadBusy();   
-        self.send_command(0x12);  #SWRESET
+        epdconfig.send_command(0x12);  #SWRESET
         self.ReadBusy();   
 
-        self.send_command(0x01); #Driver output control      
-        self.send_data(0x27);
-        self.send_data(0x01);
-        self.send_data(0x00);
+        epdconfig.send_command(0x01); #Driver output control      
+        epdconfig.send_data(0x27);
+        epdconfig.send_data(0x01);
+        epdconfig.send_data(0x00);
     
-        self.send_command(0x11); #data entry mode       
-        self.send_data(0x03);
+        epdconfig.send_command(0x11); #data entry mode       
+        epdconfig.send_data(0x03);
 
         self.SetWindow(0, 0, self.width-1, self.height-1);
 
-        self.send_command(0x21); #  Display update control
-        self.send_data(0x00);
-        self.send_data(0x80);	
+        epdconfig.send_command(0x21); #  Display update control
+        epdconfig.send_data(0x00);
+        epdconfig.send_data(0x80);	
     
         self.SetCursor(0, 0);
         self.ReadBusy();
@@ -187,25 +163,25 @@ class EPD:
     def display(self, image):
         if (image == None):
             return            
-        self.send_command(0x24) # WRITE_RAM
+        epdconfig.send_command(0x24) # WRITE_RAM
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(image[i + j * int(self.width / 8)])   
+                epdconfig.send_data(image[i + j * int(self.width / 8)])   
         self.TurnOnDisplay()
 
     def display_Base(self, image):
         if (image == None):
             return   
             
-        self.send_command(0x24) # WRITE_RAM
+        epdconfig.send_command(0x24) # WRITE_RAM
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(image[i + j * int(self.width / 8)])
+                epdconfig.send_data(image[i + j * int(self.width / 8)])
                 
-        self.send_command(0x26) # WRITE_RAM
+        epdconfig.send_command(0x26) # WRITE_RAM
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(image[i + j * int(self.width / 8)])   
+                epdconfig.send_data(image[i + j * int(self.width / 8)])   
                 
         self.TurnOnDisplay()
         
@@ -219,45 +195,45 @@ class EPD:
         epdconfig.delay_ms(2)   
         
         self.SendLut();
-        self.send_command(0x37); 
-        self.send_data(0x00);  
-        self.send_data(0x00);  
-        self.send_data(0x00);  
-        self.send_data(0x00); 
-        self.send_data(0x00);  	
-        self.send_data(0x40);  
-        self.send_data(0x00);  
-        self.send_data(0x00);   
-        self.send_data(0x00);  
-        self.send_data(0x00);
+        epdconfig.send_command(0x37); 
+        epdconfig.send_data(0x00);  
+        epdconfig.send_data(0x00);  
+        epdconfig.send_data(0x00);  
+        epdconfig.send_data(0x00); 
+        epdconfig.send_data(0x00);  	
+        epdconfig.send_data(0x40);  
+        epdconfig.send_data(0x00);  
+        epdconfig.send_data(0x00);   
+        epdconfig.send_data(0x00);  
+        epdconfig.send_data(0x00);
 
-        self.send_command(0x3C); #BorderWavefrom
-        self.send_data(0x80);
+        epdconfig.send_command(0x3C); #BorderWavefrom
+        epdconfig.send_data(0x80);
 
-        self.send_command(0x22); 
-        self.send_data(0xC0);   
-        self.send_command(0x20); 
+        epdconfig.send_command(0x22); 
+        epdconfig.send_data(0xC0);   
+        epdconfig.send_command(0x20); 
         self.ReadBusy();
 
         self.SetWindow(0, 0, self.width - 1, self.height - 1)
         self.SetCursor(0, 0)
         
-        self.send_command(0x24) # WRITE_RAM
+        epdconfig.send_command(0x24) # WRITE_RAM
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(image[i + j * int(self.width / 8)])   
+                epdconfig.send_data(image[i + j * int(self.width / 8)])   
         self.TurnOnDisplay_Partial()
 
     def Clear(self, color):
-        self.send_command(0x24) # WRITE_RAM
+        epdconfig.send_command(0x24) # WRITE_RAM
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(color)   
+                epdconfig.send_data(color)   
         self.TurnOnDisplay()
 
     def sleep(self):
-        self.send_command(0x10) # DEEP_SLEEP_MODE
-        self.send_data(0x01)
+        epdconfig.send_command(0x10) # DEEP_SLEEP_MODE
+        epdconfig.send_data(0x01)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9b_V3.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9b_V3.py
@@ -37,39 +37,15 @@ EPD_HEIGHT      = 296
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(2)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
-        
+            
     def ReadBusy(self):
         logging.debug("e-Paper busy")
-        self.send_command(0X71)
+        epdconfig.send_command(0X71)
         while(epdconfig.digital_read(self.busy_pin) == 0):      #  0: idle, 1: busy
-            self.send_command(0X71)
+            epdconfig.send_command(0X71)
             epdconfig.delay_ms(200)                
         logging.debug("e-Paper busy release")
         
@@ -77,22 +53,22 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 2, 200)
         
-        self.send_command(0x04)  
+        epdconfig.send_command(0x04)  
         self.ReadBusy()#waiting for the electronic paper IC to release the idle signal
 
-        self.send_command(0x00)    #panel setting
-        self.send_data(0x0f)   #LUT from OTP,128x296
-        self.send_data(0x89)    #Temperature sensor, boost and other related timing settings
+        epdconfig.send_command(0x00)    #panel setting
+        epdconfig.send_data(0x0f)   #LUT from OTP,128x296
+        epdconfig.send_data(0x89)    #Temperature sensor, boost and other related timing settings
 
-        self.send_command(0x61)    #resolution setting
-        self.send_data (0x80)  
-        self.send_data (0x01)  
-        self.send_data (0x28)
+        epdconfig.send_command(0x61)    #resolution setting
+        epdconfig.send_data (0x80)  
+        epdconfig.send_data (0x01)  
+        epdconfig.send_data (0x28)
 
-        self.send_command(0X50)    #VCOM AND DATA INTERVAL SETTING
-        self.send_data(0x77)   #WBmode:VBDF 17|D7 VBDW 97 VBDB 57
+        epdconfig.send_command(0X50)    #VCOM AND DATA INTERVAL SETTING
+        epdconfig.send_data(0x77)   #WBmode:VBDF 17|D7 VBDW 97 VBDB 57
                             # WBRmode:VBDF F7 VBDW 77 VBDB 37  VBDR B7
         
         return 0
@@ -123,35 +99,35 @@ class EPD:
 
     def display(self, blackimage, ryimage): # ryimage: red or yellow image
         if (blackimage != None):
-            self.send_command(0X10)
+            epdconfig.send_command(0X10)
             for i in range(0, int(self.width * self.height / 8)):
-                self.send_data(blackimage[i])        
+                epdconfig.send_data(blackimage[i])        
         if (ryimage != None):
-            self.send_command(0X13)
+            epdconfig.send_command(0X13)
             for i in range(0, int(self.width * self.height / 8)):
-                self.send_data(ryimage[i])
+                epdconfig.send_data(ryimage[i])
 
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(200) 
         self.ReadBusy()
         
     def Clear(self):
-        self.send_command(0X10)
+        epdconfig.send_command(0X10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xff)
-        self.send_command(0X13)
+            epdconfig.send_data(0xff)
+        epdconfig.send_command(0X13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xff)
+            epdconfig.send_data(0xff)
 
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(200) 
         self.ReadBusy()
         
     def sleep(self):
-        self.send_command(0X02) # power off
+        epdconfig.send_command(0X02) # power off
         self.ReadBusy()
-        self.send_command(0X07) # deep sleep
-        self.send_data(0xA5)
+        epdconfig.send_command(0X07) # deep sleep
+        epdconfig.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9bc.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9bc.py
@@ -37,33 +37,9 @@ EPD_HEIGHT      = 296
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
-        self.height = EPD_HEIGHT
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
+        self.height = EPD_HEIGHT 
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -75,24 +51,24 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
-        self.send_command(0x06) # boost
-        self.send_data (0x17)
-        self.send_data (0x17)
-        self.send_data (0x17)
-        self.send_command(0x04) # POWER_ON
+        epdconfig.send_command(0x06) # boost
+        epdconfig.send_data (0x17)
+        epdconfig.send_data (0x17)
+        epdconfig.send_data (0x17)
+        epdconfig.send_command(0x04) # POWER_ON
         self.ReadBusy()
-        self.send_command(0X00) # PANEL_SETTING
-        self.send_data(0x8F)
-        self.send_command(0X50) # VCOM_AND_DATA_INTERVAL_SETTING
-        self.send_data(0x77)
-        self.send_command(0x61) # TCON_RESOLUTION
-        self.send_data (0x80)
-        self.send_data (0x01)
-        self.send_data (0x28)
-        # self.send_command(VCM_DC_SETTING_REGISTER)
-        # self.send_data (0x0A)
+        epdconfig.send_command(0X00) # PANEL_SETTING
+        epdconfig.send_data(0x8F)
+        epdconfig.send_command(0X50) # VCOM_AND_DATA_INTERVAL_SETTING
+        epdconfig.send_data(0x77)
+        epdconfig.send_command(0x61) # TCON_RESOLUTION
+        epdconfig.send_data (0x80)
+        epdconfig.send_data (0x01)
+        epdconfig.send_data (0x28)
+        # epdconfig.send_command(VCM_DC_SETTING_REGISTER)
+        # epdconfig.send_data (0x0A)
         
         return 0
 
@@ -122,33 +98,33 @@ class EPD:
 
     def display(self, blackimage, ryimage): # ryimage: red or yellow image
         if (blackimage != None):
-            self.send_command(0X10)
+            epdconfig.send_command(0X10)
             for i in range(0, int(self.width * self.height / 8)):
-                self.send_data(blackimage[i])        
+                epdconfig.send_data(blackimage[i])        
         if (ryimage != None):
-            self.send_command(0X13)
+            epdconfig.send_command(0X13)
             for i in range(0, int(self.width * self.height / 8)):
-                self.send_data(ryimage[i])
+                epdconfig.send_data(ryimage[i])
 
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         self.ReadBusy()
         
     def Clear(self):
-        self.send_command(0X10)
+        epdconfig.send_command(0X10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xff)
-        self.send_command(0X13)
+            epdconfig.send_data(0xff)
+        epdconfig.send_command(0X13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xff)
+            epdconfig.send_data(0xff)
 
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         self.ReadBusy()
         
     def sleep(self):
-        self.send_command(0X02) # power off
+        epdconfig.send_command(0X02) # power off
         self.ReadBusy()
-        self.send_command(0X07) # deep sleep
-        self.send_data(0xA5)
+        epdconfig.send_command(0X07) # deep sleep
+        epdconfig.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9d.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9d.py
@@ -39,10 +39,7 @@ EPD_HEIGHT      = 296
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
 
@@ -146,37 +143,16 @@ class EPD:
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    ]
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
+    ] 
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
-            self.send_command(0x71)
+            epdconfig.send_command(0x71)
             epdconfig.delay_ms(100)  
         logging.debug("e-Paper busy release")
     def TurnOnDisplay(self):
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(10)
         self.ReadBusy()
         
@@ -184,82 +160,82 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
-        self.send_command(0x01)	# POWER SETTING
-        self.send_data(0x03)
-        self.send_data(0x00)
-        self.send_data(0x2b)
-        self.send_data(0x2b)
-        self.send_data(0x03)
+        epdconfig.send_command(0x01)	# POWER SETTING
+        epdconfig.send_data(0x03)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x2b)
+        epdconfig.send_data(0x2b)
+        epdconfig.send_data(0x03)
 
-        self.send_command(0x06)	# boost soft start
-        self.send_data(0x17) # A
-        self.send_data(0x17) # B
-        self.send_data(0x17) # C
+        epdconfig.send_command(0x06)	# boost soft start
+        epdconfig.send_data(0x17) # A
+        epdconfig.send_data(0x17) # B
+        epdconfig.send_data(0x17) # C
 
-        self.send_command(0x04)
+        epdconfig.send_command(0x04)
         self.ReadBusy()
 
-        self.send_command(0x00)	# panel setting
-        self.send_data(0xbf) # LUT from OTP,128x296
-        self.send_data(0x0d) # VCOM to 0V fast
+        epdconfig.send_command(0x00)	# panel setting
+        epdconfig.send_data(0xbf) # LUT from OTP,128x296
+        epdconfig.send_data(0x0d) # VCOM to 0V fast
 
-        self.send_command(0x30)	#PLL setting
-        self.send_data(0x3a)     # 3a 100HZ   29 150Hz 39 200HZ	31 171HZ
+        epdconfig.send_command(0x30)	#PLL setting
+        epdconfig.send_data(0x3a)     # 3a 100HZ   29 150Hz 39 200HZ	31 171HZ
 
-        self.send_command(0x61)	# resolution setting
-        self.send_data(self.width)
-        self.send_data((self.height >> 8) & 0xff)
-        self.send_data(self.height& 0xff)
+        epdconfig.send_command(0x61)	# resolution setting
+        epdconfig.send_data(self.width)
+        epdconfig.send_data((self.height >> 8) & 0xff)
+        epdconfig.send_data(self.height& 0xff)
 
-        self.send_command(0x82)	# vcom_DC setting
-        self.send_data(0x28)
+        epdconfig.send_command(0x82)	# vcom_DC setting
+        epdconfig.send_data(0x28)
         return 0
         
     def SetFullReg(self):
-        self.send_command(0x82)
-        self.send_data(0x00)
-        self.send_command(0X50)
-        self.send_data(0x97)
+        epdconfig.send_command(0x82)
+        epdconfig.send_data(0x00)
+        epdconfig.send_command(0X50)
+        epdconfig.send_data(0x97)
         
-        self.send_command(0x20)         # vcom
+        epdconfig.send_command(0x20)         # vcom
         for count in range(0, 44):
-            self.send_data(self.lut_vcomDC[count])
-        self.send_command(0x21)         # ww --
+            epdconfig.send_data(self.lut_vcomDC[count])
+        epdconfig.send_command(0x21)         # ww --
         for count in range(0, 42):
-            self.send_data(self.lut_ww[count])
-        self.send_command(0x22)         # bw r
+            epdconfig.send_data(self.lut_ww[count])
+        epdconfig.send_command(0x22)         # bw r
         for count in range(0, 42):
-            self.send_data(self.lut_bw[count])
-        self.send_command(0x23)         # wb w
+            epdconfig.send_data(self.lut_bw[count])
+        epdconfig.send_command(0x23)         # wb w
         for count in range(0, 42):
-            self.send_data(self.lut_wb[count])
-        self.send_command(0x24)         # bb b
+            epdconfig.send_data(self.lut_wb[count])
+        epdconfig.send_command(0x24)         # bb b
         for count in range(0, 42):
-            self.send_data(self.lut_bb[count])
+            epdconfig.send_data(self.lut_bb[count])
     
     def SetPartReg(self):
-        self.send_command(0x82)
-        self.send_data(0x03)
-        self.send_command(0X50)
-        self.send_data(0x47)
+        epdconfig.send_command(0x82)
+        epdconfig.send_data(0x03)
+        epdconfig.send_command(0X50)
+        epdconfig.send_data(0x47)
         
-        self.send_command(0x20)         # vcom
+        epdconfig.send_command(0x20)         # vcom
         for count in range(0, 44):
-            self.send_data(self.lut_vcom1[count])
-        self.send_command(0x21)         # ww --
+            epdconfig.send_data(self.lut_vcom1[count])
+        epdconfig.send_command(0x21)         # ww --
         for count in range(0, 42):
-            self.send_data(self.lut_ww1[count])
-        self.send_command(0x22)         # bw r
+            epdconfig.send_data(self.lut_ww1[count])
+        epdconfig.send_command(0x22)         # bw r
         for count in range(0, 42):
-            self.send_data(self.lut_bw1[count])
-        self.send_command(0x23)         # wb w
+            epdconfig.send_data(self.lut_bw1[count])
+        epdconfig.send_command(0x23)         # wb w
         for count in range(0, 42):
-            self.send_data(self.lut_wb1[count])
-        self.send_command(0x24)         # bb b
+            epdconfig.send_data(self.lut_wb1[count])
+        epdconfig.send_command(0x24)         # bb b
         for count in range(0, 42):
-            self.send_data(self.lut_bb1[count])
+            epdconfig.send_data(self.lut_bb1[count])
 
     def getbuffer(self, image):
         # logging.debug("bufsiz = ",int(self.width/8) * self.height)
@@ -286,14 +262,14 @@ class EPD:
         return buf
 
     def display(self, image):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
+            epdconfig.send_data(0x00)
         epdconfig.delay_ms(10)
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(image[i])
+            epdconfig.send_data(image[i])
         epdconfig.delay_ms(10)
         
         self.SetFullReg()
@@ -301,49 +277,49 @@ class EPD:
         
     def DisplayPartial(self, image):
         self.SetPartReg()
-        self.send_command(0x91)
-        self.send_command(0x90)
-        self.send_data(0)
-        self.send_data(self.width - 1)
+        epdconfig.send_command(0x91)
+        epdconfig.send_command(0x90)
+        epdconfig.send_data(0)
+        epdconfig.send_data(self.width - 1)
 
-        self.send_data(0)
-        self.send_data(0)
-        self.send_data(int(self.height / 256))
-        self.send_data(self.height % 256 - 1)
-        self.send_data(0x28)
+        epdconfig.send_data(0)
+        epdconfig.send_data(0)
+        epdconfig.send_data(int(self.height / 256))
+        epdconfig.send_data(self.height % 256 - 1)
+        epdconfig.send_data(0x28)
             
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(image[i])
+            epdconfig.send_data(image[i])
         epdconfig.delay_ms(10)
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(~image[i])
+            epdconfig.send_data(~image[i])
         epdconfig.delay_ms(10)
           
         self.TurnOnDisplay()
         
     def Clear(self, color):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
+            epdconfig.send_data(0x00)
         epdconfig.delay_ms(10)
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            epdconfig.send_data(0xFF)
         epdconfig.delay_ms(10)
         
         self.SetFullReg()
         self.TurnOnDisplay()
 
     def sleep(self):
-        self.send_command(0X50)
-        self.send_data(0xf7)
-        self.send_command(0X02)         #power off
-        self.send_command(0X07)         #deep sleep  
-        self.send_data(0xA5)
+        epdconfig.send_command(0X50)
+        epdconfig.send_data(0xf7)
+        epdconfig.send_command(0X02)         #power off
+        epdconfig.send_command(0X07)         #deep sleep  
+        epdconfig.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in7.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in7.py
@@ -40,10 +40,7 @@ GRAY3  = 0x80 #Close to balck
 GRAY4  = 0x00 #balck
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
         self.GRAY1  = GRAY1 #white
@@ -106,30 +103,6 @@ class EPD:
         0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, 
         0x22,0x22,0x22,0x22,0x22
     ]
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
-
 
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -142,98 +115,98 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(300)
         
-        self.send_command(0x46)
-        self.send_data(0xF7)
+        epdconfig.send_command(0x46)
+        epdconfig.send_data(0xF7)
         self.ReadBusy()
-        self.send_command(0x47)
-        self.send_data(0xF7)
+        epdconfig.send_command(0x47)
+        epdconfig.send_data(0xF7)
         self.ReadBusy()
         
-        self.send_command(0x01) # setting gaet number
-        self.send_data(0xDF)
-        self.send_data(0x01)
-        self.send_data(0x00)
+        epdconfig.send_command(0x01) # setting gaet number
+        epdconfig.send_data(0xDF)
+        epdconfig.send_data(0x01)
+        epdconfig.send_data(0x00)
 
-        self.send_command(0x03) # set gate voltage
-        self.send_data(0x00)
+        epdconfig.send_command(0x03) # set gate voltage
+        epdconfig.send_data(0x00)
 
-        self.send_command(0x04) # set source voltage
-        self.send_data(0x41)
-        self.send_data(0xA8)
-        self.send_data(0x32)
+        epdconfig.send_command(0x04) # set source voltage
+        epdconfig.send_data(0x41)
+        epdconfig.send_data(0xA8)
+        epdconfig.send_data(0x32)
 
-        self.send_command(0x11) # set data entry sequence
-        self.send_data(0x03)
+        epdconfig.send_command(0x11) # set data entry sequence
+        epdconfig.send_data(0x03)
 
-        self.send_command(0x3C) # set border 
-        self.send_data(0x03)
+        epdconfig.send_command(0x3C) # set border 
+        epdconfig.send_data(0x03)
         
-        self.send_command(0x0C) # set booster strength
-        self.send_data(0xAE)
-        self.send_data(0xC7)
-        self.send_data(0xC3)
-        self.send_data(0xC0)
-        self.send_data(0xC0)
+        epdconfig.send_command(0x0C) # set booster strength
+        epdconfig.send_data(0xAE)
+        epdconfig.send_data(0xC7)
+        epdconfig.send_data(0xC3)
+        epdconfig.send_data(0xC0)
+        epdconfig.send_data(0xC0)
 
-        self.send_command(0x18) # set internal sensor on
-        self.send_data(0x80)
+        epdconfig.send_command(0x18) # set internal sensor on
+        epdconfig.send_data(0x80)
          
-        self.send_command(0x2C) # set vcom value
-        self.send_data(0x44)
+        epdconfig.send_command(0x2C) # set vcom value
+        epdconfig.send_data(0x44)
         
         if(mode == 0):   #4Gray
-            self.send_command(0x37) # set display option, these setting turn on previous function
-            self.send_data(0x00)
-            self.send_data(0x00)
-            self.send_data(0x00)
-            self.send_data(0x00)
-            self.send_data(0x00)  
-            self.send_data(0x00)
-            self.send_data(0x00)
-            self.send_data(0x00)
-            self.send_data(0x00)
-            self.send_data(0x00)  
+            epdconfig.send_command(0x37) # set display option, these setting turn on previous function
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)  
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)
+            epdconfig.send_data(0x00)  
         elif(mode == 1):      #1Gray
-            self.send_command(0x37) # set display option, these setting turn on previous function
-            self.send_data(0x00)     #can switch 1 gray or 4 gray
-            self.send_data(0xFF)
-            self.send_data(0xFF)
-            self.send_data(0xFF)
-            self.send_data(0xFF)  
-            self.send_data(0x4F)
-            self.send_data(0xFF)
-            self.send_data(0xFF)
-            self.send_data(0xFF)
-            self.send_data(0xFF)
+            epdconfig.send_command(0x37) # set display option, these setting turn on previous function
+            epdconfig.send_data(0x00)     #can switch 1 gray or 4 gray
+            epdconfig.send_data(0xFF)
+            epdconfig.send_data(0xFF)
+            epdconfig.send_data(0xFF)
+            epdconfig.send_data(0xFF)  
+            epdconfig.send_data(0x4F)
+            epdconfig.send_data(0xFF)
+            epdconfig.send_data(0xFF)
+            epdconfig.send_data(0xFF)
+            epdconfig.send_data(0xFF)
         else:
             logging.debug("There is no such mode") 
 
-        self.send_command(0x44) # setting X direction start/end position of RAM
-        self.send_data(0x00)
-        self.send_data(0x00)
-        self.send_data(0x17)
-        self.send_data(0x01)
+        epdconfig.send_command(0x44) # setting X direction start/end position of RAM
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x17)
+        epdconfig.send_data(0x01)
 
-        self.send_command(0x45) # setting Y direction start/end position of RAM
-        self.send_data(0x00)
-        self.send_data(0x00)
-        self.send_data(0xDF)
-        self.send_data(0x01)
+        epdconfig.send_command(0x45) # setting Y direction start/end position of RAM
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0xDF)
+        epdconfig.send_data(0x01)
 
-        self.send_command(0x22) # Display Update Control 2
-        self.send_data(0xCF)
+        epdconfig.send_command(0x22) # Display Update Control 2
+        epdconfig.send_data(0xCF)
         return 0
 
 
     def load_lut(self, lut):
-        self.send_command(0x32)
+        epdconfig.send_command(0x32)
         for i in range(0, 105):
-            self.send_data(lut[i])
+            epdconfig.send_data(lut[i])
 
 
     def getbuffer(self, image):
@@ -302,14 +275,14 @@ class EPD:
         if (image == None):
             return            
 
-        self.send_command(0x4E)
-        self.send_data(0x00)
-        self.send_data(0x00)
-        self.send_command(0x4F)
-        self.send_data(0x00)
-        self.send_data(0x00)
+        epdconfig.send_command(0x4E)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00)
+        epdconfig.send_command(0x4F)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00)
 
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for i in range(0, (int)(self.height*(self.width/8))):
             temp3=0
             for j in range(0, 2):
@@ -338,16 +311,16 @@ class EPD:
                     if(j!=1 or k!=1):
                         temp3 <<= 1
                     temp1 <<= 2
-            self.send_data(temp3)
+            epdconfig.send_data(temp3)
 
-        self.send_command(0x4E)
-        self.send_data(0x00)
-        self.send_data(0x00)
-        self.send_command(0x4F)
-        self.send_data(0x00)
-        self.send_data(0x00)
+        epdconfig.send_command(0x4E)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00)
+        epdconfig.send_command(0x4F)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00)
 
-        self.send_command(0x26)
+        epdconfig.send_command(0x26)
         for i in range(0, (int)(self.height*(self.width/8))):
             temp3=0
             for j in range(0, 2):
@@ -376,12 +349,12 @@ class EPD:
                     if(j!=1 or k!=1):
                         temp3 <<= 1
                     temp1 <<= 2
-            self.send_data(temp3)
+            epdconfig.send_data(temp3)
 
         self.load_lut(self.lut_4Gray_GC)
-        self.send_command(0x22)
-        self.send_data(0xC7)
-        self.send_command(0x20)
+        epdconfig.send_command(0x22)
+        epdconfig.send_data(0xC7)
+        epdconfig.send_command(0x20)
         self.ReadBusy()   
 
 
@@ -389,59 +362,59 @@ class EPD:
         if (image == None):
             return            
 
-        self.send_command(0x4E)
-        self.send_data(0x00)
-        self.send_data(0x00)
-        self.send_command(0x4F)
-        self.send_data(0x00)
-        self.send_data(0x00)
+        epdconfig.send_command(0x4E)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00)
+        epdconfig.send_command(0x4F)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00)
 
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(image[i + j * int(self.width / 8)])   
+                epdconfig.send_data(image[i + j * int(self.width / 8)])   
 
         self.load_lut(self.lut_1Gray_A2)
-        self.send_command(0x20)
+        epdconfig.send_command(0x20)
         self.ReadBusy()   
         
 
     def Clear(self, color, mode):
-        self.send_command(0x4E)
-        self.send_data(0x00)
-        self.send_data(0x00)
-        self.send_command(0x4F)
-        self.send_data(0x00)
-        self.send_data(0x00)
+        epdconfig.send_command(0x4E)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00)
+        epdconfig.send_command(0x4F)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x00)
 
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for j in range(0, self.height):
             for i in range(0, int(self.width / 8)):
-                self.send_data(0xff)   
+                epdconfig.send_data(0xff)   
 
         if(mode == 0):              #4Gray
-            self.send_command(0x26)
+            epdconfig.send_command(0x26)
             for j in range(0, self.height):
                 for i in range(0, int(self.width / 8)):
-                    self.send_data(0xff) 
+                    epdconfig.send_data(0xff) 
             self.load_lut(self.lut_4Gray_GC)
-            self.send_command(0x22)
-            self.send_data(0xC7)
+            epdconfig.send_command(0x22)
+            epdconfig.send_data(0xC7)
         elif(mode == 1):            #1Gray
             self.load_lut(self.lut_1Gray_DU)
         else:
             logging.debug("There is no such mode") 
 
-        self.send_command(0x20)
+        epdconfig.send_command(0x20)
         self.ReadBusy()   
 
 
     def sleep(self):
-        self.send_command(0X50) # DEEP_SLEEP_MODE
-        self.send_data(0xf7)
-        self.send_command(0X02) #power off
-        self.send_command(0X07) #deep sleep
-        self.send_data(0xA5)
+        epdconfig.send_command(0X50) # DEEP_SLEEP_MODE
+        epdconfig.send_data(0xf7)
+        epdconfig.send_command(0X02) #power off
+        epdconfig.send_command(0X07) #deep sleep
+        epdconfig.send_data(0xA5)
 
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in01f.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in01f.py
@@ -38,10 +38,7 @@ EPD_HEIGHT      = 400
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
         self.BLACK  = 0x000000   #   0000  BGR
@@ -51,28 +48,6 @@ class EPD:
         self.RED    = 0x0000ff   #   0100
         self.YELLOW = 0x00ffff   #   0101
         self.ORANGE = 0x0080ff   #   0110
-        
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(1)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusyHigh(self):
         logging.debug("e-Paper busy")
@@ -90,36 +65,36 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 1, 200)
         
         self.ReadBusyHigh()
-        self.send_command(0x00);
-        self.send_data(0x2f);
-        self.send_data(0x00);
-        self.send_command(0x01);
-        self.send_data(0x37);
-        self.send_data(0x00);
-        self.send_data(0x05);
-        self.send_data(0x05);
-        self.send_command(0x03);
-        self.send_data(0x00);
-        self.send_command(0x06);
-        self.send_data(0xC7);
-        self.send_data(0xC7);
-        self.send_data(0x1D);
-        self.send_command(0x41);
-        self.send_data(0x00);
-        self.send_command(0x50);
-        self.send_data(0x37);
-        self.send_command(0x60);
-        self.send_data(0x22);
-        self.send_command(0x61);
-        self.send_data(0x02);
-        self.send_data(0x80);
-        self.send_data(0x01);
-        self.send_data(0x90);
-        self.send_command(0xE3);
-        self.send_data(0xAA);
+        epdconfig.send_command(0x00);
+        epdconfig.send_data(0x2f);
+        epdconfig.send_data(0x00);
+        epdconfig.send_command(0x01);
+        epdconfig.send_data(0x37);
+        epdconfig.send_data(0x00);
+        epdconfig.send_data(0x05);
+        epdconfig.send_data(0x05);
+        epdconfig.send_command(0x03);
+        epdconfig.send_data(0x00);
+        epdconfig.send_command(0x06);
+        epdconfig.send_data(0xC7);
+        epdconfig.send_data(0xC7);
+        epdconfig.send_data(0x1D);
+        epdconfig.send_command(0x41);
+        epdconfig.send_data(0x00);
+        epdconfig.send_command(0x50);
+        epdconfig.send_data(0x37);
+        epdconfig.send_command(0x60);
+        epdconfig.send_data(0x22);
+        epdconfig.send_command(0x61);
+        epdconfig.send_data(0x02);
+        epdconfig.send_data(0x80);
+        epdconfig.send_data(0x01);
+        epdconfig.send_data(0x90);
+        epdconfig.send_command(0xE3);
+        epdconfig.send_data(0xAA);
         
         # EPD hardware init end
         return 0
@@ -181,33 +156,33 @@ class EPD:
         return buf
 
     def display(self,image):
-        self.send_command(0x61)#Set Resolution setting
-        self.send_data(0x02)
-        self.send_data(0x80)
-        self.send_data(0x01)
-        self.send_data(0x90)
-        self.send_command(0x10)
+        epdconfig.send_command(0x61)#Set Resolution setting
+        epdconfig.send_data(0x02)
+        epdconfig.send_data(0x80)
+        epdconfig.send_data(0x01)
+        epdconfig.send_data(0x90)
+        epdconfig.send_command(0x10)
         for i in range(0, int(EPD_HEIGHT)):
             for j in range(0, int(EPD_WIDTH/2)):
-                self.send_data((image[j+(int(EPD_WIDTH/2)*i)]))
-        self.send_command(0x04)#0x04
+                epdconfig.send_data((image[j+(int(EPD_WIDTH/2)*i)]))
+        epdconfig.send_command(0x04)#0x04
         self.ReadBusyHigh()
-        self.send_command(0x12)#0x12
+        epdconfig.send_command(0x12)#0x12
         self.ReadBusyHigh()
-        self.send_command(0x02)  #0x02
+        epdconfig.send_command(0x02)  #0x02
         self.ReadBusyLow()
         # epdconfig.delay_ms(500)
         
     def Clear(self):
-        self.send_command(0x61)#Set Resolution setting
-        self.send_data(0x02)
-        self.send_data(0x80)
-        self.send_data(0x01)
-        self.send_data(0x90)
-        self.send_command(0x10)
+        epdconfig.send_command(0x61)#Set Resolution setting
+        epdconfig.send_data(0x02)
+        epdconfig.send_data(0x80)
+        epdconfig.send_data(0x01)
+        epdconfig.send_data(0x90)
+        epdconfig.send_command(0x10)
         for i in range(0, int(EPD_HEIGHT)):
             for j in range(0, int(EPD_WIDTH/2)):
-                self.send_data(0x11)
+                epdconfig.send_data(0x11)
         #BLACK   0x00    /// 0000
         #WHITE   0x11    /// 0001
         #GREEN   0x22    /// 0010
@@ -216,18 +191,18 @@ class EPD:
         #YELLOW  0x55    /// 0101
         #ORANGE  0x66    /// 0110
         #CLEAN   0x77    /// 0111   unavailable  Afterimage
-        self.send_command(0x04)#0x04
+        epdconfig.send_command(0x04)#0x04
         self.ReadBusyHigh()
-        self.send_command(0x12)#0x12
+        epdconfig.send_command(0x12)#0x12
         self.ReadBusyHigh()
-        self.send_command(0x02)  #0x02
+        epdconfig.send_command(0x02)  #0x02
         self.ReadBusyLow()
         # epdconfig.delay_ms(500)
 
     def sleep(self):
         # epdconfig.delay_ms(500)
-        self.send_command(0x07) # DEEP_SLEEP
-        self.send_data(0XA5)
+        epdconfig.send_command(0x07) # DEEP_SLEEP
+        epdconfig.send_data(0XA5)
 
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()   

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2.py
@@ -44,10 +44,7 @@ GRAY4  = 0x00 #Blackest
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
         self.GRAY1  = GRAY1 #white
@@ -198,143 +195,122 @@ class EPD:
     0x00	,0x00	,0x00	,0x00	,0x00	,0x00,
     0x00	,0x00	,0x00	,0x00	,0x00	,0x00,
     ]
-    
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        self.send_command(0x71)
+        epdconfig.send_command(0x71)
         while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
-            self.send_command(0x71)
+            epdconfig.send_command(0x71)
             epdconfig.delay_ms(100)    
 
     def set_lut(self):
-        self.send_command(0x20)               # vcom
+        epdconfig.send_command(0x20)               # vcom
         for count in range(0, 44):
-            self.send_data(self.lut_vcom0[count])
+            epdconfig.send_data(self.lut_vcom0[count])
             
-        self.send_command(0x21)         # ww --
+        epdconfig.send_command(0x21)         # ww --
         for count in range(0, 42):
-            self.send_data(self.lut_ww[count])
+            epdconfig.send_data(self.lut_ww[count])
             
-        self.send_command(0x22)         # bw r
+        epdconfig.send_command(0x22)         # bw r
         for count in range(0, 42):
-            self.send_data(self.lut_bw[count])
+            epdconfig.send_data(self.lut_bw[count])
             
-        self.send_command(0x23)         # wb w
+        epdconfig.send_command(0x23)         # wb w
         for count in range(0, 42):
-            self.send_data(self.lut_bb[count])
+            epdconfig.send_data(self.lut_bb[count])
             
-        self.send_command(0x24)         # bb b
+        epdconfig.send_command(0x24)         # bb b
         for count in range(0, 42):
-            self.send_data(self.lut_wb[count])
+            epdconfig.send_data(self.lut_wb[count])
 
 
     def Partial_SetLut(self):
-        self.send_command(0x20);
+        epdconfig.send_command(0x20);
         for count in range(0, 44):	     
-            self.send_data(self.EPD_4IN2_Partial_lut_vcom1[count])
+            epdconfig.send_data(self.EPD_4IN2_Partial_lut_vcom1[count])
 
-        self.send_command(0x21);
+        epdconfig.send_command(0x21);
         for count in range(0, 42):	     
-            self.send_data(self.EPD_4IN2_Partial_lut_ww1[count])
+            epdconfig.send_data(self.EPD_4IN2_Partial_lut_ww1[count])
         
-        self.send_command(0x22);
+        epdconfig.send_command(0x22);
         for count in range(0, 42):     
-            self.send_data(self.EPD_4IN2_Partial_lut_bw1[count])
+            epdconfig.send_data(self.EPD_4IN2_Partial_lut_bw1[count])
 
-        self.send_command(0x23);
+        epdconfig.send_command(0x23);
         for count in range(0, 42):	     
-            self.send_data(self.EPD_4IN2_Partial_lut_wb1[count])
+            epdconfig.send_data(self.EPD_4IN2_Partial_lut_wb1[count])
 
-        self.send_command(0x24);
+        epdconfig.send_command(0x24);
         for count in range(0, 42):	     
-            self.send_data(self.EPD_4IN2_Partial_lut_bb1[count])
+            epdconfig.send_data(self.EPD_4IN2_Partial_lut_bb1[count])
 
 
        
     def Gray_SetLut(self):
-        self.send_command(0x20)						#vcom
+        epdconfig.send_command(0x20)						#vcom
         for count in range(0, 42):
-            self.send_data(self.EPD_4IN2_4Gray_lut_vcom[count]) 
+            epdconfig.send_data(self.EPD_4IN2_4Gray_lut_vcom[count]) 
 
-        self.send_command(0x21)						#red not use
+        epdconfig.send_command(0x21)						#red not use
         for count in range(0, 42):
-            self.send_data(self.EPD_4IN2_4Gray_lut_ww[count]) 
+            epdconfig.send_data(self.EPD_4IN2_4Gray_lut_ww[count]) 
 
-        self.send_command(0x22)							#bw r
+        epdconfig.send_command(0x22)							#bw r
         for count in range(0, 42):
-            self.send_data(self.EPD_4IN2_4Gray_lut_bw[count]) 
+            epdconfig.send_data(self.EPD_4IN2_4Gray_lut_bw[count]) 
 
-        self.send_command(0x23)							#wb w
+        epdconfig.send_command(0x23)							#wb w
         for count in range(0, 42):
-            self.send_data(self.EPD_4IN2_4Gray_lut_wb[count]) 
+            epdconfig.send_data(self.EPD_4IN2_4Gray_lut_wb[count]) 
 
-        self.send_command(0x24)                          #bb b
+        epdconfig.send_command(0x24)                          #bb b
         for count in range(0, 42):
-            self.send_data(self.EPD_4IN2_4Gray_lut_bb[count]) 
+            epdconfig.send_data(self.EPD_4IN2_4Gray_lut_bb[count]) 
 
-        self.send_command(0x25)						#vcom
+        epdconfig.send_command(0x25)						#vcom
         for count in range(0, 42):
-            self.send_data(self.EPD_4IN2_4Gray_lut_ww[count])
+            epdconfig.send_data(self.EPD_4IN2_4Gray_lut_ww[count])
       
     
     def init(self):
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
-        self.send_command(0x01) # POWER SETTING
-        self.send_data(0x03) # VDS_EN, VDG_EN
-        self.send_data(0x00) # VCOM_HV, VGHL_LV[1], VGHL_LV[0]
-        self.send_data(0x2b) # VDH
-        self.send_data(0x2b) # VDL
+        epdconfig.send_command(0x01) # POWER SETTING
+        epdconfig.send_data(0x03) # VDS_EN, VDG_EN
+        epdconfig.send_data(0x00) # VCOM_HV, VGHL_LV[1], VGHL_LV[0]
+        epdconfig.send_data(0x2b) # VDH
+        epdconfig.send_data(0x2b) # VDL
         
-        self.send_command(0x06) # boost soft start
-        self.send_data(0x17)
-        self.send_data(0x17)
-        self.send_data(0x17)
+        epdconfig.send_command(0x06) # boost soft start
+        epdconfig.send_data(0x17)
+        epdconfig.send_data(0x17)
+        epdconfig.send_data(0x17)
         
-        self.send_command(0x04) # POWER_ON
+        epdconfig.send_command(0x04) # POWER_ON
         self.ReadBusy()
         
-        self.send_command(0x00) # panel setting
-        self.send_data(0xbf) # KW-BF   KWR-AF  BWROTP 0f
-        self.send_data(0x0d)
+        epdconfig.send_command(0x00) # panel setting
+        epdconfig.send_data(0xbf) # KW-BF   KWR-AF  BWROTP 0f
+        epdconfig.send_data(0x0d)
         
-        self.send_command(0x30) # PLL setting
-        self.send_data(0x3c) # 3A 100HZ   29 150Hz 39 200HZ  31 171HZ
+        epdconfig.send_command(0x30) # PLL setting
+        epdconfig.send_data(0x3c) # 3A 100HZ   29 150Hz 39 200HZ  31 171HZ
 
-        self.send_command(0x61)	# resolution setting
-        self.send_data(0x01)
-        self.send_data(0x90) # 128
-        self.send_data(0x01)		
-        self.send_data(0x2c)
+        epdconfig.send_command(0x61)	# resolution setting
+        epdconfig.send_data(0x01)
+        epdconfig.send_data(0x90) # 128
+        epdconfig.send_data(0x01)		
+        epdconfig.send_data(0x2c)
 
-        self.send_command(0x82)	# vcom_DC setting
-        self.send_data(0x28)
+        epdconfig.send_command(0x82)	# vcom_DC setting
+        epdconfig.send_data(0x28)
 
-        self.send_command(0X50)	# VCOM AND DATA INTERVAL SETTING
-        self.send_data(0x97) # 97white border 77black border		VBDF 17|D7 VBDW 97 VBDB 57		VBDF F7 VBDW 77 VBDB 37  VBDR B7
+        epdconfig.send_command(0X50)	# VCOM AND DATA INTERVAL SETTING
+        epdconfig.send_data(0x97) # 97white border 77black border		VBDF 17|D7 VBDW 97 VBDB 57		VBDF F7 VBDW 77 VBDB 37  VBDR B7
     
         self.set_lut()
         # EPD hardware init end
@@ -344,40 +320,40 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
-        self.send_command(0x01)			#POWER SETTING
-        self.send_data (0x03)
-        self.send_data (0x00)       #VGH=20V,VGL=-20V
-        self.send_data (0x2b)		#VDH=15V															 
-        self.send_data (0x2b)		#VDL=-15V
-        self.send_data (0x13)
+        epdconfig.send_command(0x01)			#POWER SETTING
+        epdconfig.send_data (0x03)
+        epdconfig.send_data (0x00)       #VGH=20V,VGL=-20V
+        epdconfig.send_data (0x2b)		#VDH=15V															 
+        epdconfig.send_data (0x2b)		#VDL=-15V
+        epdconfig.send_data (0x13)
 
-        self.send_command(0x06)         #booster soft start
-        self.send_data (0x17)		#A
-        self.send_data (0x17)		#B
-        self.send_data (0x17)		#C 
+        epdconfig.send_command(0x06)         #booster soft start
+        epdconfig.send_data (0x17)		#A
+        epdconfig.send_data (0x17)		#B
+        epdconfig.send_data (0x17)		#C 
 
-        self.send_command(0x04)
+        epdconfig.send_command(0x04)
         self.ReadBusy()
 
-        self.send_command(0x00)			#panel setting
-        self.send_data(0x3f)		#KW-3f   KWR-2F	BWROTP 0f	BWOTP 1f
+        epdconfig.send_command(0x00)			#panel setting
+        epdconfig.send_data(0x3f)		#KW-3f   KWR-2F	BWROTP 0f	BWOTP 1f
 
-        self.send_command(0x30)			#PLL setting
-        self.send_data (0x3c)      	#100hz 
+        epdconfig.send_command(0x30)			#PLL setting
+        epdconfig.send_data (0x3c)      	#100hz 
 
-        self.send_command(0x61)			#resolution setting
-        self.send_data (0x01)		#400
-        self.send_data (0x90)     	 
-        self.send_data (0x01)		#300
-        self.send_data (0x2c)
+        epdconfig.send_command(0x61)			#resolution setting
+        epdconfig.send_data (0x01)		#400
+        epdconfig.send_data (0x90)     	 
+        epdconfig.send_data (0x01)		#300
+        epdconfig.send_data (0x2c)
 
-        self.send_command(0x82)			#vcom_DC setting
-        self.send_data (0x12)
+        epdconfig.send_command(0x82)			#vcom_DC setting
+        epdconfig.send_data (0x12)
 
-        self.send_command(0X50)			#VCOM AND DATA INTERVAL SETTING			
-        self.send_data(0x97)
+        epdconfig.send_command(0X50)			#VCOM AND DATA INTERVAL SETTING			
+        epdconfig.send_data(0x97)
 
     def getbuffer(self, image):
         # logging.debug("bufsiz = ",int(self.width/8) * self.height)
@@ -441,17 +417,17 @@ class EPD:
         return buf
 
     def display(self, image):
-        self.send_command(0x92);	
+        epdconfig.send_command(0x92);	
         self.set_lut();
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            epdconfig.send_data(0xFF)
             
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(image[i])
+            epdconfig.send_data(image[i])
             
-        self.send_command(0x12) 
+        epdconfig.send_command(0x12) 
         self.ReadBusy()
 
     def EPD_4IN2_PartialDisplay(self, X_start, Y_start, X_end, Y_end, Image):
@@ -469,41 +445,41 @@ class EPD:
             X_end = int(X_end/8)*8+8
         
         self.Partial_SetLut();
-        self.send_command(0x91);		#This command makes the display enter partial mode
-        self.send_command(0x90);		#resolution setting
-        self.send_data (int(X_start/256));
-        self.send_data (int(X_start%256));   #x-start    
+        epdconfig.send_command(0x91);		#This command makes the display enter partial mode
+        epdconfig.send_command(0x90);		#resolution setting
+        epdconfig.send_data (int(X_start/256));
+        epdconfig.send_data (int(X_start%256));   #x-start    
         
-        self.send_data (int(X_end /256));		
-        self.send_data (int(X_end %256)-1);  #x-end
+        epdconfig.send_data (int(X_end /256));		
+        epdconfig.send_data (int(X_end %256)-1);  #x-end
 
-        self.send_data (int(Y_start/256));
-        self.send_data (int(Y_start%256));   #y-start    
+        epdconfig.send_data (int(Y_start/256));
+        epdconfig.send_data (int(Y_start%256));   #y-start    
         
 
-        self.send_data (int(Y_end/256));		
-        self.send_data (int(Y_end%256)-1);  #y-end
-        self.send_data (0x28);	
+        epdconfig.send_data (int(Y_end/256));		
+        epdconfig.send_data (int(Y_end%256)-1);  #y-end
+        epdconfig.send_data (0x28);	
 
-        self.send_command(0x10);	       #writes Old data to SRAM for programming
+        epdconfig.send_command(0x10);	       #writes Old data to SRAM for programming
         for j in range(0, int(Y_end - Y_start)):
             for i in range(0, int(X_end/8) - int(X_start/8)):
-                self.send_data(Image[(Y_start + j)*Width + int(X_start/8) + i]);
+                epdconfig.send_data(Image[(Y_start + j)*Width + int(X_start/8) + i]);
             
-        self.send_command(0x13);				 #writes New data to SRAM.
+        epdconfig.send_command(0x13);				 #writes New data to SRAM.
         for j in range(0, int(Y_end - Y_start)):
             for i in range(0, int(X_end/8) - int(X_start/8)):
-                self.send_data(~Image[(Y_start + j)*Width + int(X_start/8) + i]);
+                epdconfig.send_data(~Image[(Y_start + j)*Width + int(X_start/8) + i]);
             
-        self.send_command(0x12);		 #DISPLAY REFRESH 		             
+        epdconfig.send_command(0x12);		 #DISPLAY REFRESH 		             
         epdconfig.delay_ms(200)    #The delay here is necessary, 200uS at least!!!     
         self.ReadBusy()
 
 
     def display_4Gray(self, image):
-        self.send_command(0x92);	
+        epdconfig.send_command(0x92);	
         self.set_lut();
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(EPD_WIDTH * EPD_HEIGHT / 8)):                   # EPD_WIDTH * EPD_HEIGHT / 4
             temp3=0
             for j in range(0, 2):
@@ -533,9 +509,9 @@ class EPD:
                     if(j!=1 or k!=1):				
                         temp3 <<= 1
                     temp1 <<= 2
-            self.send_data(temp3)
+            epdconfig.send_data(temp3)
             
-        self.send_command(0x13)	    
+        epdconfig.send_command(0x13)	    
                
         for i in range(0, int(EPD_WIDTH * EPD_HEIGHT / 8)):                #5808*4  46464
             temp3=0
@@ -566,31 +542,31 @@ class EPD:
                     if(j!=1 or k!=1):					
                         temp3 <<= 1
                     temp1 <<= 2
-            self.send_data(temp3)
+            epdconfig.send_data(temp3)
         
         self.Gray_SetLut()
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(200)
         self.ReadBusy()
         # pass
     
     def Clear(self):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            epdconfig.send_data(0xFF)
             
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            epdconfig.send_data(0xFF)
             
-        self.send_command(0x12) 
+        epdconfig.send_command(0x12) 
         self.ReadBusy()
 
     def sleep(self):
-        self.send_command(0x02) # POWER_OFF
+        epdconfig.send_command(0x02) # POWER_OFF
         self.ReadBusy()
-        self.send_command(0x07) # DEEP_SLEEP
-        self.send_data(0XA5)
+        epdconfig.send_command(0x07) # DEEP_SLEEP
+        epdconfig.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2b_V2.py
@@ -36,39 +36,15 @@ EPD_HEIGHT      = 300
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
-        self.height = EPD_HEIGHT
-
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
+        self.height = EPD_HEIGHT 
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
-        self.send_command(0x71);
+        epdconfig.send_command(0x71);
         while(epdconfig.digital_read(self.busy_pin) == 0): # 0: idle, 1: busy
-            self.send_command(0x71);
+            epdconfig.send_command(0x71);
             epdconfig.delay_ms(20)
         logging.debug("e-Paper busy release")
             
@@ -76,13 +52,13 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
             
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
-        self.send_command(0x04); 
+        epdconfig.send_command(0x04); 
         self.ReadBusy();
 
-        self.send_command(0x00);
-        self.send_data(0x0f);
+        epdconfig.send_command(0x00);
+        epdconfig.send_data(0x0f);
         
         return 0
 
@@ -111,39 +87,39 @@ class EPD:
         return buf
 
     def display(self, imageblack, imagered):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(imageblack[i])
+            epdconfig.send_data(imageblack[i])
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(imagered[i])
+            epdconfig.send_data(imagered[i])
         
-        self.send_command(0x12) 
+        epdconfig.send_command(0x12) 
         epdconfig.delay_ms(20)
         self.ReadBusy()
         
     def Clear(self):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            epdconfig.send_data(0xFF)
             
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            epdconfig.send_data(0xFF)
         
-        self.send_command(0x12) 
+        epdconfig.send_command(0x12) 
         epdconfig.delay_ms(20)
         self.ReadBusy()
 
     def sleep(self):
-        self.send_command(0X50);
-        self.send_data(0xf7);		#border floating	
+        epdconfig.send_command(0X50);
+        epdconfig.send_data(0xf7);		#border floating	
 
-        self.send_command(0X02);  	#power off
+        epdconfig.send_command(0X02);  	#power off
         self.ReadBusy(); #waiting for the electronic paper IC to release the idle signal
-        self.send_command(0X07);  	#deep sleep
-        self.send_data(0xA5);
+        epdconfig.send_command(0X07);  	#deep sleep
+        epdconfig.send_data(0xA5);
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2bc.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2bc.py
@@ -36,33 +36,9 @@ EPD_HEIGHT      = 300
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
-
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -74,18 +50,18 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
             
-        self.reset()
+        epdconfig.reset(200, 5, 200)
 
-        self.send_command(0x06) # BOOSTER_SOFT_START
-        self.send_data (0x17)
-        self.send_data (0x17)
-        self.send_data (0x17) # 07 0f 17 1f 27 2F 37 2f
+        epdconfig.send_command(0x06) # BOOSTER_SOFT_START
+        epdconfig.send_data (0x17)
+        epdconfig.send_data (0x17)
+        epdconfig.send_data (0x17) # 07 0f 17 1f 27 2F 37 2f
         
-        self.send_command(0x04) # POWER_ON
+        epdconfig.send_command(0x04) # POWER_ON
         self.ReadBusy()
         
-        self.send_command(0x00) # PANEL_SETTING
-        self.send_data(0x0F) # LUT from OTP
+        epdconfig.send_command(0x00) # PANEL_SETTING
+        epdconfig.send_data(0x0F) # LUT from OTP
         
         return 0
 
@@ -114,34 +90,34 @@ class EPD:
         return buf
 
     def display(self, imageblack, imagered):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(imageblack[i])
+            epdconfig.send_data(imageblack[i])
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(imagered[i])
+            epdconfig.send_data(imagered[i])
         
-        self.send_command(0x12) 
+        epdconfig.send_command(0x12) 
         self.ReadBusy()
         
     def Clear(self):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            epdconfig.send_data(0xFF)
             
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            epdconfig.send_data(0xFF)
         
-        self.send_command(0x12) 
+        epdconfig.send_command(0x12) 
         self.ReadBusy()
 
     def sleep(self):
-        self.send_command(0x02) # POWER_OFF
+        epdconfig.send_command(0x02) # POWER_OFF
         self.ReadBusy()
-        self.send_command(0x07) # DEEP_SLEEP
-        self.send_data(0xA5) # check code
+        epdconfig.send_command(0x07) # DEEP_SLEEP
+        epdconfig.send_data(0xA5) # check code
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in65f.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in65f.py
@@ -38,10 +38,7 @@ EPD_HEIGHT      = 448
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
         self.BLACK  = 0x000000   #   0000  BGR
@@ -51,28 +48,6 @@ class EPD:
         self.RED    = 0x0000ff   #   0100
         self.YELLOW = 0x00ffff   #   0101
         self.ORANGE = 0x0080ff   #   0110
-        
-        
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(600) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(2)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusyHigh(self):
         logging.debug("e-Paper busy")
@@ -90,42 +65,42 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(600, 2, 200)
         
         self.ReadBusyHigh()
-        self.send_command(0x00)
-        self.send_data(0xEF)
-        self.send_data(0x08)
-        self.send_command(0x01)
-        self.send_data(0x37)
-        self.send_data(0x00)
-        self.send_data(0x23)
-        self.send_data(0x23)
-        self.send_command(0x03)
-        self.send_data(0x00)
-        self.send_command(0x06)
-        self.send_data(0xC7)
-        self.send_data(0xC7)
-        self.send_data(0x1D)
-        self.send_command(0x30)
-        self.send_data(0x3c)
-        self.send_command(0x40)
-        self.send_data(0x00)
-        self.send_command(0x50)
-        self.send_data(0x37)
-        self.send_command(0x60)
-        self.send_data(0x22)
-        self.send_command(0x61)
-        self.send_data(0x02)
-        self.send_data(0x58)
-        self.send_data(0x01)
-        self.send_data(0xC0)
-        self.send_command(0xE3)
-        self.send_data(0xAA)
+        epdconfig.send_command(0x00)
+        epdconfig.send_data(0xEF)
+        epdconfig.send_data(0x08)
+        epdconfig.send_command(0x01)
+        epdconfig.send_data(0x37)
+        epdconfig.send_data(0x00)
+        epdconfig.send_data(0x23)
+        epdconfig.send_data(0x23)
+        epdconfig.send_command(0x03)
+        epdconfig.send_data(0x00)
+        epdconfig.send_command(0x06)
+        epdconfig.send_data(0xC7)
+        epdconfig.send_data(0xC7)
+        epdconfig.send_data(0x1D)
+        epdconfig.send_command(0x30)
+        epdconfig.send_data(0x3c)
+        epdconfig.send_command(0x40)
+        epdconfig.send_data(0x00)
+        epdconfig.send_command(0x50)
+        epdconfig.send_data(0x37)
+        epdconfig.send_command(0x60)
+        epdconfig.send_data(0x22)
+        epdconfig.send_command(0x61)
+        epdconfig.send_data(0x02)
+        epdconfig.send_data(0x58)
+        epdconfig.send_data(0x01)
+        epdconfig.send_data(0xC0)
+        epdconfig.send_command(0xE3)
+        epdconfig.send_data(0xAA)
         
         epdconfig.delay_ms(100)
-        self.send_command(0x50)
-        self.send_data(0x37)
+        epdconfig.send_command(0x50)
+        epdconfig.send_data(0x37)
         # EPD hardware init end
         return 0
 
@@ -186,33 +161,33 @@ class EPD:
         return buf
 
     def display(self,image):
-        self.send_command(0x61)#Set Resolution setting
-        self.send_data(0x02)
-        self.send_data(0x58)
-        self.send_data(0x01)
-        self.send_data(0xC0)
-        self.send_command(0x10)
+        epdconfig.send_command(0x61)#Set Resolution setting
+        epdconfig.send_data(0x02)
+        epdconfig.send_data(0x58)
+        epdconfig.send_data(0x01)
+        epdconfig.send_data(0xC0)
+        epdconfig.send_command(0x10)
         for i in range(0, int(EPD_HEIGHT)):
             for j in range(0, int(EPD_WIDTH/2)):
-                self.send_data((image[j+(int(EPD_WIDTH/2)*i)]))
-        self.send_command(0x04)#0x04
+                epdconfig.send_data((image[j+(int(EPD_WIDTH/2)*i)]))
+        epdconfig.send_command(0x04)#0x04
         self.ReadBusyHigh()
-        self.send_command(0x12)#0x12
+        epdconfig.send_command(0x12)#0x12
         self.ReadBusyHigh()
-        self.send_command(0x02)  #0x02
+        epdconfig.send_command(0x02)  #0x02
         self.ReadBusyLow()
         epdconfig.delay_ms(500)
         
     def Clear(self):
-        self.send_command(0x61)#Set Resolution setting
-        self.send_data(0x02)
-        self.send_data(0x58)
-        self.send_data(0x01)
-        self.send_data(0xC0)
-        self.send_command(0x10)
+        epdconfig.send_command(0x61)#Set Resolution setting
+        epdconfig.send_data(0x02)
+        epdconfig.send_data(0x58)
+        epdconfig.send_data(0x01)
+        epdconfig.send_data(0xC0)
+        epdconfig.send_command(0x10)
         for i in range(0, int(EPD_HEIGHT)):
             for j in range(0, int(EPD_WIDTH/2)):
-                self.send_data(0x11)
+                epdconfig.send_data(0x11)
         #BLACK   0x00    /// 0000
         #WHITE   0x11    /// 0001
         #GREEN   0x22    /// 0010
@@ -221,18 +196,18 @@ class EPD:
         #YELLOW  0x55    /// 0101
         #ORANGE  0x66    /// 0110
         #CLEAN   0x77    /// 0111   unavailable  Afterimage
-        self.send_command(0x04)#0x04
+        epdconfig.send_command(0x04)#0x04
         self.ReadBusyHigh()
-        self.send_command(0x12)#0x12
+        epdconfig.send_command(0x12)#0x12
         self.ReadBusyHigh()
-        self.send_command(0x02)  #0x02
+        epdconfig.send_command(0x02)  #0x02
         self.ReadBusyLow()
         epdconfig.delay_ms(500)
 
     def sleep(self):
         epdconfig.delay_ms(500)
-        self.send_command(0x07) # DEEP_SLEEP
-        self.send_data(0XA5)
+        epdconfig.send_command(0x07) # DEEP_SLEEP
+        epdconfig.send_data(0XA5)
         epdconfig.digital_write(self.reset_pin, 0)
 
         epdconfig.delay_ms(2000)

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83.py
@@ -37,33 +37,9 @@ EPD_HEIGHT      = 448
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
-    
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(2)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -75,47 +51,47 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 2, 200)
         
-        self.send_command(0x01) # POWER_SETTING
-        self.send_data(0x37)
-        self.send_data(0x00)
+        epdconfig.send_command(0x01) # POWER_SETTING
+        epdconfig.send_data(0x37)
+        epdconfig.send_data(0x00)
         
-        self.send_command(0x00) # PANEL_SETTING
-        self.send_data(0xCF)
-        self.send_data(0x08)
+        epdconfig.send_command(0x00) # PANEL_SETTING
+        epdconfig.send_data(0xCF)
+        epdconfig.send_data(0x08)
         
-        self.send_command(0x06) # BOOSTER_SOFT_START
-        self.send_data(0xc7)
-        self.send_data(0xcc)
-        self.send_data(0x28)
+        epdconfig.send_command(0x06) # BOOSTER_SOFT_START
+        epdconfig.send_data(0xc7)
+        epdconfig.send_data(0xcc)
+        epdconfig.send_data(0x28)
         
-        self.send_command(0x04) # POWER_ON
+        epdconfig.send_command(0x04) # POWER_ON
         self.ReadBusy()
         
-        self.send_command(0x30) # PLL_CONTROL
-        self.send_data(0x3c)
+        epdconfig.send_command(0x30) # PLL_CONTROL
+        epdconfig.send_data(0x3c)
         
-        self.send_command(0x41) # TEMPERATURE_CALIBRATION
-        self.send_data(0x00)
+        epdconfig.send_command(0x41) # TEMPERATURE_CALIBRATION
+        epdconfig.send_data(0x00)
         
-        self.send_command(0x50) # VCOM_AND_DATA_INTERVAL_SETTING
-        self.send_data(0x77)
+        epdconfig.send_command(0x50) # VCOM_AND_DATA_INTERVAL_SETTING
+        epdconfig.send_data(0x77)
         
-        self.send_command(0x60) # TCON_SETTING
-        self.send_data(0x22)
+        epdconfig.send_command(0x60) # TCON_SETTING
+        epdconfig.send_data(0x22)
         
-        self.send_command(0x61) # TCON_RESOLUTION
-        self.send_data(0x02) # source 600
-        self.send_data(0x58)
-        self.send_data(0x01) # gate 448
-        self.send_data(0xC0)
+        epdconfig.send_command(0x61) # TCON_RESOLUTION
+        epdconfig.send_data(0x02) # source 600
+        epdconfig.send_data(0x58)
+        epdconfig.send_data(0x01) # gate 448
+        epdconfig.send_data(0xC0)
         
-        self.send_command(0x82) # VCM_DC_SETTING
-        self.send_data(0x1E) # decide by LUT file
+        epdconfig.send_command(0x82) # VCM_DC_SETTING
+        epdconfig.send_data(0x1E) # decide by LUT file
         
-        self.send_command(0xe5) # FLASH MODE
-        self.send_data(0x03)
+        epdconfig.send_command(0xe5) # FLASH MODE
+        epdconfig.send_data(0x03)
         
         # EPD hardware init end
         return 0
@@ -152,7 +128,7 @@ class EPD:
         return buf
 
     def display(self, image):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width / 4 * self.height)):
             temp1 = image[i]
             j = 0
@@ -173,26 +149,26 @@ class EPD:
                 else:
                     temp2 |= 0x04
                 temp1 = (temp1 << 2) & 0xFF
-                self.send_data(temp2)
+                epdconfig.send_data(temp2)
                 j += 1
                 
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(100)
         self.ReadBusy()
         
     def Clear(self):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width / 4 * self.height)):
             for j in range(0, 4):
-                self.send_data(0x33)
-        self.send_command(0x12)
+                epdconfig.send_data(0x33)
+        epdconfig.send_command(0x12)
         self.ReadBusy()
 
     def sleep(self):
-        self.send_command(0x02) # POWER_OFF
+        epdconfig.send_command(0x02) # POWER_OFF
         self.ReadBusy()
-        self.send_command(0x07) # DEEP_SLEEP
-        self.send_data(0XA5)
+        epdconfig.send_command(0x07) # DEEP_SLEEP
+        epdconfig.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83_V2.py
@@ -36,33 +36,9 @@ EPD_HEIGHT      = 480
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
-    
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(2)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -71,7 +47,7 @@ class EPD:
         logging.debug("e-Paper busy release")
         
     def TurnOnDisplay(self):
-        self.send_command(0x12);    #POWER ON
+        epdconfig.send_command(0x12);    #POWER ON
         epdconfig.delay_ms(100)   
         self.ReadBusy();  
     
@@ -79,36 +55,36 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 2, 200)
         
-        self.send_command(0x01)    #POWER SETTING
-        self.send_data (0x07)
-        self.send_data (0x07)  #VGH=20V,VGL=-20V
-        self.send_data (0x3f)  #VDH=15V
-        self.send_data (0x3f)  #VDL=-15V
+        epdconfig.send_command(0x01)    #POWER SETTING
+        epdconfig.send_data (0x07)
+        epdconfig.send_data (0x07)  #VGH=20V,VGL=-20V
+        epdconfig.send_data (0x3f)  #VDH=15V
+        epdconfig.send_data (0x3f)  #VDL=-15V
 
-        self.send_command(0x04)    #POWER ON
+        epdconfig.send_command(0x04)    #POWER ON
         epdconfig.delay_ms(100) 
         self.ReadBusy()   #waiting for the electronic paper IC to release the idle signal
 
-        self.send_command(0X00)    #PANNEL SETTING
-        self.send_data(0x1F)   #KW-3f   KWR-2F	BWROTP 0f	BWOTP 1f
+        epdconfig.send_command(0X00)    #PANNEL SETTING
+        epdconfig.send_data(0x1F)   #KW-3f   KWR-2F	BWROTP 0f	BWOTP 1f
 
-        self.send_command(0x61)    #tres
-        self.send_data (0x02)		#source 648
-        self.send_data (0x88)
-        self.send_data (0x01)		#gate 480
-        self.send_data (0xE0)
+        epdconfig.send_command(0x61)    #tres
+        epdconfig.send_data (0x02)		#source 648
+        epdconfig.send_data (0x88)
+        epdconfig.send_data (0x01)		#gate 480
+        epdconfig.send_data (0xE0)
 
-        self.send_command(0X15)		
-        self.send_data(0x00)		
+        epdconfig.send_command(0X15)		
+        epdconfig.send_data(0x00)		
 
-        self.send_command(0X50)			#VCOM AND DATA INTERVAL SETTING
-        self.send_data(0x10)
-        self.send_data(0x07)
+        epdconfig.send_command(0X50)			#VCOM AND DATA INTERVAL SETTING
+        epdconfig.send_data(0x10)
+        epdconfig.send_data(0x07)
 
-        self.send_command(0X60)			#TCON SETTING
-        self.send_data(0x22)
+        epdconfig.send_command(0X60)			#TCON SETTING
+        epdconfig.send_data(0x22)
             
         # EPD hardware init end
         return 0
@@ -138,28 +114,28 @@ class EPD:
         return buf
         
     def display(self, image):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
-        self.send_command(0x13)
+            epdconfig.send_data(0x00)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(~image[i])
+            epdconfig.send_data(~image[i])
         self.TurnOnDisplay()
         
     def Clear(self):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
-        self.send_command(0x13)
+            epdconfig.send_data(0x00)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
+            epdconfig.send_data(0x00)
         self.TurnOnDisplay()
 
     def sleep(self):
-        self.send_command(0x02) # POWER_OFF
+        epdconfig.send_command(0x02) # POWER_OFF
         self.ReadBusy()
-        self.send_command(0x07) # DEEP_SLEEP
-        self.send_data(0XA5)
+        epdconfig.send_command(0x07) # DEEP_SLEEP
+        epdconfig.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83b_V2.py
@@ -37,39 +37,15 @@ EPD_HEIGHT      = 480
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
-        self.height = EPD_HEIGHT
-
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(1)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
+        self.height = EPD_HEIGHT 
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
-        self.send_command(0X71)
+        epdconfig.send_command(0X71)
         while(epdconfig.digital_read(self.busy_pin) == 0):      #  0: idle, 1: busy
-            self.send_command(0X71)
+            epdconfig.send_command(0X71)
             epdconfig.delay_ms(200)
         logging.debug("e-Paper busy release")
             
@@ -77,36 +53,36 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
             
-        self.reset()
+        epdconfig.reset(200, 1, 200)
 
-        self.send_command(0x01)     #POWER SETTING
-        self.send_data (0x07)
-        self.send_data (0x07)       #VGH=20V,VGL=-20V
-        self.send_data (0x3f)       #VDH=15V
-        self.send_data (0x3f)       #VDL=-15V
+        epdconfig.send_command(0x01)     #POWER SETTING
+        epdconfig.send_data (0x07)
+        epdconfig.send_data (0x07)       #VGH=20V,VGL=-20V
+        epdconfig.send_data (0x3f)       #VDH=15V
+        epdconfig.send_data (0x3f)       #VDL=-15V
 
-        self.send_command(0x04) #POWER ON
+        epdconfig.send_command(0x04) #POWER ON
         epdconfig.delay_ms(100)  
         self.ReadBusy()   #waiting for the electronic paper IC to release the idle signal
 
-        self.send_command(0X00)     #PANNEL SETTING
-        self.send_data(0x0F)        #KW-3f   KWR-2F    BWROTP 0f   BWOTP 1f
+        epdconfig.send_command(0X00)     #PANNEL SETTING
+        epdconfig.send_data(0x0F)        #KW-3f   KWR-2F    BWROTP 0f   BWOTP 1f
 
-        self.send_command(0x61)     #tres
-        self.send_data (0x02)       #source 648
-        self.send_data (0x88)
-        self.send_data (0x01)       #gate 480
-        self.send_data (0xe0)
+        epdconfig.send_command(0x61)     #tres
+        epdconfig.send_data (0x02)       #source 648
+        epdconfig.send_data (0x88)
+        epdconfig.send_data (0x01)       #gate 480
+        epdconfig.send_data (0xe0)
 
-        self.send_command(0X15)
-        self.send_data(0x00)
+        epdconfig.send_command(0X15)
+        epdconfig.send_data(0x00)
 
-        self.send_command(0X50)     #VCOM AND DATA INTERVAL SETTING
-        self.send_data(0x11)
-        self.send_data(0x07)
+        epdconfig.send_command(0X50)     #VCOM AND DATA INTERVAL SETTING
+        epdconfig.send_data(0x11)
+        epdconfig.send_data(0x07)
 
-        self.send_command(0X60)     #TCON SETTING
-        self.send_data(0x22)
+        epdconfig.send_command(0X60)     #TCON SETTING
+        epdconfig.send_data(0x22)
         
         return 0
 
@@ -136,35 +112,35 @@ class EPD:
 
     def display(self, imageblack, imagered):
         if (imageblack != None):
-            self.send_command(0X10)
+            epdconfig.send_command(0X10)
             for i in range(0, int(self.width * self.height / 8)):
-                self.send_data(imageblack[i])        
+                epdconfig.send_data(imageblack[i])        
         if (imagered != None):
-            self.send_command(0X13)
+            epdconfig.send_command(0X13)
             for i in range(0, int(self.width * self.height / 8)):
-                self.send_data(~imagered[i])
+                epdconfig.send_data(~imagered[i])
 
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(200) 
         self.ReadBusy()
 
     def Clear(self):
-        self.send_command(0X10)
+        epdconfig.send_command(0X10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xff)
-        self.send_command(0X13)
+            epdconfig.send_data(0xff)
+        epdconfig.send_command(0X13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
+            epdconfig.send_data(0x00)
 
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(200) 
         self.ReadBusy()
 
     def sleep(self):
-        self.send_command(0X02) # power off
+        epdconfig.send_command(0X02) # power off
         self.ReadBusy()
-        self.send_command(0X07) # deep sleep
-        self.send_data(0xA5)
+        epdconfig.send_command(0X07) # deep sleep
+        epdconfig.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83bc.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83bc.py
@@ -37,33 +37,9 @@ EPD_HEIGHT      = 448
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
-
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -75,44 +51,44 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
             
-        self.reset()
+        epdconfig.reset(200, 5, 200)
 
-        self.send_command(0x01) # POWER_SETTING
-        self.send_data(0x37)
-        self.send_data(0x00)
+        epdconfig.send_command(0x01) # POWER_SETTING
+        epdconfig.send_data(0x37)
+        epdconfig.send_data(0x00)
         
-        self.send_command(0x00) # PANEL_SETTING
-        self.send_data(0xCF)
-        self.send_data(0x08)
+        epdconfig.send_command(0x00) # PANEL_SETTING
+        epdconfig.send_data(0xCF)
+        epdconfig.send_data(0x08)
         
-        self.send_command(0x30) # PLL_CONTROL
-        self.send_data(0x3A) # PLL:  0-15:0x3C, 15+:0x3A
-        self.send_command(0X82) # VCOM VOLTAGE SETTING
-        self.send_data(0x28) # all temperature  range
+        epdconfig.send_command(0x30) # PLL_CONTROL
+        epdconfig.send_data(0x3A) # PLL:  0-15:0x3C, 15+:0x3A
+        epdconfig.send_command(0X82) # VCOM VOLTAGE SETTING
+        epdconfig.send_data(0x28) # all temperature  range
 
-        self.send_command(0x06) # boost
-        self.send_data(0xc7) 	   	
-        self.send_data(0xcc) 
-        self.send_data(0x15) 
+        epdconfig.send_command(0x06) # boost
+        epdconfig.send_data(0xc7) 	   	
+        epdconfig.send_data(0xcc) 
+        epdconfig.send_data(0x15) 
 
-        self.send_command(0X50) # VCOM AND DATA INTERVAL SETTING
-        self.send_data(0x77) 
+        epdconfig.send_command(0X50) # VCOM AND DATA INTERVAL SETTING
+        epdconfig.send_data(0x77) 
 
-        self.send_command(0X60) # TCON SETTING
-        self.send_data(0x22) 
+        epdconfig.send_command(0X60) # TCON SETTING
+        epdconfig.send_data(0x22) 
 
-        self.send_command(0X65) # FLASH CONTROL
-        self.send_data(0x00)
+        epdconfig.send_command(0X65) # FLASH CONTROL
+        epdconfig.send_data(0x00)
 
-        self.send_command(0x61) # tres			
-        self.send_data(0x02) # source 600
-        self.send_data(0x58) 
-        self.send_data(0x01) # gate 448
-        self.send_data(0xc0)
+        epdconfig.send_command(0x61) # tres			
+        epdconfig.send_data(0x02) # source 600
+        epdconfig.send_data(0x58) 
+        epdconfig.send_data(0x01) # gate 448
+        epdconfig.send_data(0xc0)
 
-        self.send_command(0xe5) # FLASH MODE		   	
-        self.send_data(0x03) 
-        self.send_data(0x03)
+        epdconfig.send_command(0xe5) # FLASH MODE		   	
+        epdconfig.send_data(0x03) 
+        epdconfig.send_data(0x03)
         
         return 0
 
@@ -141,7 +117,7 @@ class EPD:
         return buf
 
     def display(self, imageblack, imagered):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width / 8 * self.height)):
             temp1 = imageblack[i]
             temp2 = imagered[i]
@@ -166,34 +142,34 @@ class EPD:
                     temp3 |= 0x03              #white
                 temp1 = (temp1 << 1) & 0xFF
                 temp2 = (temp2 << 1) & 0xFF
-                self.send_data(temp3)
+                epdconfig.send_data(temp3)
                 j += 1
                 
-        self.send_command(0x04) # POWER ON
+        epdconfig.send_command(0x04) # POWER ON
         self.ReadBusy()
-        self.send_command(0x12) # display refresh
+        epdconfig.send_command(0x12) # display refresh
         epdconfig.delay_ms(100)
         self.ReadBusy()
         
     def Clear(self):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width / 8 * self.height)):
-            self.send_data(0x33)
-            self.send_data(0x33)
-            self.send_data(0x33)
-            self.send_data(0x33)
+            epdconfig.send_data(0x33)
+            epdconfig.send_data(0x33)
+            epdconfig.send_data(0x33)
+            epdconfig.send_data(0x33)
             
-        self.send_command(0x04) # POWER ON
+        epdconfig.send_command(0x04) # POWER ON
         self.ReadBusy()
-        self.send_command(0x12) # display refresh
+        epdconfig.send_command(0x12) # display refresh
         epdconfig.delay_ms(100)
         self.ReadBusy()
 
     def sleep(self):
-        self.send_command(0x02) # POWER_OFF
+        epdconfig.send_command(0x02) # POWER_OFF
         self.ReadBusy()
-        self.send_command(0x07) # DEEP_SLEEP
-        self.send_data(0xA5) # check code
+        epdconfig.send_command(0x07) # DEEP_SLEEP
+        epdconfig.send_data(0xA5) # check code
     
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5.py
@@ -37,39 +37,9 @@ EPD_HEIGHT      = 384
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
-    
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
-        
-    def send_data2(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte2(data)
-        epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -81,43 +51,43 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 5, 200)
         
-        self.send_command(0x01) # POWER_SETTING
-        self.send_data2([0x37, 0x00])
+        epdconfig.send_command(0x01) # POWER_SETTING
+        epdconfig.send_data2([0x37, 0x00])
         
-        self.send_command(0x00) # PANEL_SETTING
-        self.send_data2([0xCF, 0x08])
+        epdconfig.send_command(0x00) # PANEL_SETTING
+        epdconfig.send_data2([0xCF, 0x08])
         
-        self.send_command(0x06) # BOOSTER_SOFT_START
-        self.send_data2([0xc7, 0xcc, 0x28])
+        epdconfig.send_command(0x06) # BOOSTER_SOFT_START
+        epdconfig.send_data2([0xc7, 0xcc, 0x28])
         
-        self.send_command(0x04) # POWER_ON
+        epdconfig.send_command(0x04) # POWER_ON
         self.ReadBusy()
         
-        self.send_command(0x30) # PLL_CONTROL
-        self.send_data(0x3c)
+        epdconfig.send_command(0x30) # PLL_CONTROL
+        epdconfig.send_data(0x3c)
         
-        self.send_command(0x41) # TEMPERATURE_CALIBRATION
-        self.send_data(0x00)
+        epdconfig.send_command(0x41) # TEMPERATURE_CALIBRATION
+        epdconfig.send_data(0x00)
         
-        self.send_command(0x50) # VCOM_AND_DATA_INTERVAL_SETTING
-        self.send_data(0x77)
+        epdconfig.send_command(0x50) # VCOM_AND_DATA_INTERVAL_SETTING
+        epdconfig.send_data(0x77)
         
-        self.send_command(0x60) # TCON_SETTING
-        self.send_data(0x22)
+        epdconfig.send_command(0x60) # TCON_SETTING
+        epdconfig.send_data(0x22)
         
-        self.send_command(0x61) # TCON_RESOLUTION
-        self.send_data(EPD_WIDTH >> 8)     #source 640
-        self.send_data(EPD_WIDTH & 0xff)
-        self.send_data(EPD_HEIGHT >> 8)     #gate 384
-        self.send_data(EPD_HEIGHT & 0xff)
+        epdconfig.send_command(0x61) # TCON_RESOLUTION
+        epdconfig.send_data(EPD_WIDTH >> 8)     #source 640
+        epdconfig.send_data(EPD_WIDTH & 0xff)
+        epdconfig.send_data(EPD_HEIGHT >> 8)     #gate 384
+        epdconfig.send_data(EPD_HEIGHT & 0xff)
         
-        self.send_command(0x82) # VCM_DC_SETTING
-        self.send_data(0x1E) # decide by LUT file
+        epdconfig.send_command(0x82) # VCM_DC_SETTING
+        epdconfig.send_data(0x1E) # decide by LUT file
         
-        self.send_command(0xe5) # FLASH MODE
-        self.send_data(0x03)
+        epdconfig.send_command(0xe5) # FLASH MODE
+        epdconfig.send_data(0x03)
         
         # EPD hardware init end
         return 0
@@ -157,25 +127,25 @@ class EPD:
         return buf
         
     def display(self, image):
-        self.send_command(0x10)
-        self.send_data2(image)
-        self.send_command(0x12)
+        epdconfig.send_command(0x10)
+        epdconfig.send_data2(image)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(100)
         self.ReadBusy()
         
     def Clear(self):
         buf = [0x33] * int(self.width * self.height / 2)
-        self.send_command(0x10)
-        self.send_data2(buf)
-        self.send_command(0x12)
+        epdconfig.send_command(0x10)
+        epdconfig.send_data2(buf)
+        epdconfig.send_command(0x12)
         self.ReadBusy()
 
     def sleep(self):
-        self.send_command(0x02) # POWER_OFF
+        epdconfig.send_command(0x02) # POWER_OFF
         self.ReadBusy()
         
-        self.send_command(0x07) # DEEP_SLEEP
-        self.send_data(0XA5)
+        epdconfig.send_command(0x07) # DEEP_SLEEP
+        epdconfig.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_HD.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_HD.py
@@ -37,39 +37,9 @@ EPD_HEIGHT      = 528
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
-    
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(2)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
-        
-    def send_data2(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte2(data)
-        epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -82,49 +52,49 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 2, 200)
         
         self.ReadBusy();
-        self.send_command(0x12);  #SWRESET
+        epdconfig.send_command(0x12);  #SWRESET
         self.ReadBusy();
 
-        self.send_command(0x46);  # Auto Write Red RAM
-        self.send_data(0xf7);
+        epdconfig.send_command(0x46);  # Auto Write Red RAM
+        epdconfig.send_data(0xf7);
         self.ReadBusy();
-        self.send_command(0x47);  # Auto Write  B/W RAM
-        self.send_data(0xf7);
-        self.ReadBusy();
-
-        self.send_command(0x0C);  # Soft start setting
-        self.send_data2([0xAE, 0xC7, 0xC3, 0xC0, 0x40])
-
-        self.send_command(0x01);  # Set MUX as 527
-        self.send_data2([0xAF, 0x02, 0x01])
-
-        self.send_command(0x11);  # Data entry mode      
-        self.send_data(0x01);
-
-        self.send_command(0x44); 
-        self.send_data2([0x00, 0x00, 0x6F, 0x03]) # RAM x address start at 0
-        self.send_command(0x45); 
-        self.send_data2([0xAF, 0x02, 0x00, 0x00])
-
-        self.send_command(0x3C); # VBD
-        self.send_data(0x05); # LUT1, for white
-
-        self.send_command(0x18);
-        self.send_data(0X80);
-
-
-        self.send_command(0x22);
-        self.send_data(0XB1); #Load Temperature and waveform setting.
-        self.send_command(0x20);
+        epdconfig.send_command(0x47);  # Auto Write  B/W RAM
+        epdconfig.send_data(0xf7);
         self.ReadBusy();
 
-        self.send_command(0x4E); # set RAM x address count to 0;
-        self.send_data2([0x00, 0x00])
-        self.send_command(0x4F); 
-        self.send_data2([0x00, 0x00])
+        epdconfig.send_command(0x0C);  # Soft start setting
+        epdconfig.send_data2([0xAE, 0xC7, 0xC3, 0xC0, 0x40])
+
+        epdconfig.send_command(0x01);  # Set MUX as 527
+        epdconfig.send_data2([0xAF, 0x02, 0x01])
+
+        epdconfig.send_command(0x11);  # Data entry mode      
+        epdconfig.send_data(0x01);
+
+        epdconfig.send_command(0x44); 
+        epdconfig.send_data2([0x00, 0x00, 0x6F, 0x03]) # RAM x address start at 0
+        epdconfig.send_command(0x45); 
+        epdconfig.send_data2([0xAF, 0x02, 0x00, 0x00])
+
+        epdconfig.send_command(0x3C); # VBD
+        epdconfig.send_data(0x05); # LUT1, for white
+
+        epdconfig.send_command(0x18);
+        epdconfig.send_data(0X80);
+
+
+        epdconfig.send_command(0x22);
+        epdconfig.send_data(0XB1); #Load Temperature and waveform setting.
+        epdconfig.send_command(0x20);
+        self.ReadBusy();
+
+        epdconfig.send_command(0x4E); # set RAM x address count to 0;
+        epdconfig.send_data2([0x00, 0x00])
+        epdconfig.send_command(0x4F); 
+        epdconfig.send_data2([0x00, 0x00])
         # EPD hardware init end
         return 0
 
@@ -144,35 +114,35 @@ class EPD:
         return buf
         
     def display(self, image):
-        self.send_command(0x4F); 
-        self.send_data2([0x00, 0x00])
-        self.send_command(0x24);
-        self.send_data2(image)
-        self.send_command(0x22);
-        self.send_data(0xF7);#Load LUT from MCU(0x32)
-        self.send_command(0x20);
+        epdconfig.send_command(0x4F); 
+        epdconfig.send_data2([0x00, 0x00])
+        epdconfig.send_command(0x24);
+        epdconfig.send_data2(image)
+        epdconfig.send_command(0x22);
+        epdconfig.send_data(0xF7);#Load LUT from MCU(0x32)
+        epdconfig.send_command(0x20);
         epdconfig.delay_ms(10);
         self.ReadBusy();
         
     def Clear(self):
         buf = [0xff] * int(self.width * self.height / 8)
-        self.send_command(0x4F); 
-        self.send_data2([0x00, 0x00])
-        self.send_command(0x24)
-        self.send_data2(buf)
+        epdconfig.send_command(0x4F); 
+        epdconfig.send_data2([0x00, 0x00])
+        epdconfig.send_command(0x24)
+        epdconfig.send_data2(buf)
             
-        self.send_command(0x26)
-        self.send_data2(buf)
+        epdconfig.send_command(0x26)
+        epdconfig.send_data2(buf)
                 
-        self.send_command(0x22);
-        self.send_data(0xF7);#Load LUT from MCU(0x32)
-        self.send_command(0x20);
+        epdconfig.send_command(0x22);
+        epdconfig.send_data(0xF7);#Load LUT from MCU(0x32)
+        epdconfig.send_command(0x20);
         epdconfig.delay_ms(10);
         self.ReadBusy();
 
     def sleep(self):
-        self.send_command(0x10);
-        self.send_data(0x01);
+        epdconfig.send_command(0x10);
+        epdconfig.send_data(0x01);
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
@@ -37,40 +37,16 @@ EPD_HEIGHT      = 480
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
-    
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(2)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
-        self.send_command(0x71)
+        epdconfig.send_command(0x71)
         busy = epdconfig.digital_read(self.busy_pin)
         while(busy == 0):
-            self.send_command(0x71)
+            epdconfig.send_command(0x71)
             busy = epdconfig.digital_read(self.busy_pin)
         epdconfig.delay_ms(200)
         
@@ -78,36 +54,36 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
-        self.reset()
+        epdconfig.reset(200, 2, 200)
         
-        self.send_command(0x01)			#POWER SETTING
-        self.send_data(0x07)
-        self.send_data(0x07)    #VGH=20V,VGL=-20V
-        self.send_data(0x3f)		#VDH=15V
-        self.send_data(0x3f)		#VDL=-15V
+        epdconfig.send_command(0x01)			#POWER SETTING
+        epdconfig.send_data(0x07)
+        epdconfig.send_data(0x07)    #VGH=20V,VGL=-20V
+        epdconfig.send_data(0x3f)		#VDH=15V
+        epdconfig.send_data(0x3f)		#VDL=-15V
 
-        self.send_command(0x04) #POWER ON
+        epdconfig.send_command(0x04) #POWER ON
         epdconfig.delay_ms(100)
         self.ReadBusy()
 
-        self.send_command(0X00)			#PANNEL SETTING
-        self.send_data(0x1F)   #KW-3f   KWR-2F	BWROTP 0f	BWOTP 1f
+        epdconfig.send_command(0X00)			#PANNEL SETTING
+        epdconfig.send_data(0x1F)   #KW-3f   KWR-2F	BWROTP 0f	BWOTP 1f
 
-        self.send_command(0x61)        	#tres
-        self.send_data(0x03)		#source 800
-        self.send_data(0x20)
-        self.send_data(0x01)		#gate 480
-        self.send_data(0xE0)
+        epdconfig.send_command(0x61)        	#tres
+        epdconfig.send_data(0x03)		#source 800
+        epdconfig.send_data(0x20)
+        epdconfig.send_data(0x01)		#gate 480
+        epdconfig.send_data(0xE0)
 
-        self.send_command(0X15)
-        self.send_data(0x00)
+        epdconfig.send_command(0X15)
+        epdconfig.send_data(0x00)
 
-        self.send_command(0X50)			#VCOM AND DATA INTERVAL SETTING
-        self.send_data(0x10)
-        self.send_data(0x07)
+        epdconfig.send_command(0X50)			#VCOM AND DATA INTERVAL SETTING
+        epdconfig.send_data(0x10)
+        epdconfig.send_data(0x07)
 
-        self.send_command(0X60)			#TCON SETTING
-        self.send_data(0x22)
+        epdconfig.send_command(0X60)			#TCON SETTING
+        epdconfig.send_data(0x22)
 
         # EPD hardware init end
         return 0
@@ -137,33 +113,33 @@ class EPD:
         return buf
         
     def display(self, image):
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(~image[i])
+            epdconfig.send_data(~image[i])
                 
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(100)
         self.ReadBusy()
         
     def Clear(self):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
+            epdconfig.send_data(0x00)
             
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
+            epdconfig.send_data(0x00)
                 
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(100)
         self.ReadBusy()
 
     def sleep(self):
-        self.send_command(0x02) # POWER_OFF
+        epdconfig.send_command(0x02) # POWER_OFF
         self.ReadBusy()
         
-        self.send_command(0x07) # DEEP_SLEEP
-        self.send_data(0XA5)
+        epdconfig.send_command(0x07) # DEEP_SLEEP
+        epdconfig.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5b_HD.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5b_HD.py
@@ -37,33 +37,9 @@ EPD_HEIGHT      = 528
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
-
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(4)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -76,61 +52,61 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
             
-        self.reset()
+        epdconfig.reset(200, 4, 200)
         
-        self.send_command(0x12); 		  #SWRESET
+        epdconfig.send_command(0x12); 		  #SWRESET
         self.ReadBusy();        #waiting for the electronic paper IC to release the idle signal
 
-        self.send_command(0x46);  # Auto Write RAM
-        self.send_data(0xF7);
+        epdconfig.send_command(0x46);  # Auto Write RAM
+        epdconfig.send_data(0xF7);
         self.ReadBusy();        #waiting for the electronic paper IC to release the idle signal
 
-        self.send_command(0x47);  # Auto Write RAM
-        self.send_data(0xF7);
+        epdconfig.send_command(0x47);  # Auto Write RAM
+        epdconfig.send_data(0xF7);
         self.ReadBusy();        #waiting for the electronic paper IC to release the idle signal
 
-        self.send_command(0x0C);  # Soft start setting
-        self.send_data(0xAE);
-        self.send_data(0xC7);
-        self.send_data(0xC3);
-        self.send_data(0xC0);
-        self.send_data(0x40);   
+        epdconfig.send_command(0x0C);  # Soft start setting
+        epdconfig.send_data(0xAE);
+        epdconfig.send_data(0xC7);
+        epdconfig.send_data(0xC3);
+        epdconfig.send_data(0xC0);
+        epdconfig.send_data(0x40);   
 
-        self.send_command(0x01);  # Set MUX as 527
-        self.send_data(0xAF);
-        self.send_data(0x02);
-        self.send_data(0x01);
+        epdconfig.send_command(0x01);  # Set MUX as 527
+        epdconfig.send_data(0xAF);
+        epdconfig.send_data(0x02);
+        epdconfig.send_data(0x01);
 
-        self.send_command(0x11);  # Data entry mode
-        self.send_data(0x01);
+        epdconfig.send_command(0x11);  # Data entry mode
+        epdconfig.send_data(0x01);
 
-        self.send_command(0x44);
-        self.send_data(0x00); # RAM x address start at 0
-        self.send_data(0x00);
-        self.send_data(0x6F); # RAM x address end at 36Fh -> 879
-        self.send_data(0x03);
-        self.send_command(0x45);
-        self.send_data(0xAF); # RAM y address start at 20Fh;
-        self.send_data(0x02);
-        self.send_data(0x00); # RAM y address end at 00h;
-        self.send_data(0x00);
+        epdconfig.send_command(0x44);
+        epdconfig.send_data(0x00); # RAM x address start at 0
+        epdconfig.send_data(0x00);
+        epdconfig.send_data(0x6F); # RAM x address end at 36Fh -> 879
+        epdconfig.send_data(0x03);
+        epdconfig.send_command(0x45);
+        epdconfig.send_data(0xAF); # RAM y address start at 20Fh;
+        epdconfig.send_data(0x02);
+        epdconfig.send_data(0x00); # RAM y address end at 00h;
+        epdconfig.send_data(0x00);
 
-        self.send_command(0x3C); # VBD
-        self.send_data(0x01); # LUT1, for white
+        epdconfig.send_command(0x3C); # VBD
+        epdconfig.send_data(0x01); # LUT1, for white
 
-        self.send_command(0x18);
-        self.send_data(0X80);
-        self.send_command(0x22);
-        self.send_data(0XB1);	#Load Temperature and waveform setting.
-        self.send_command(0x20);
+        epdconfig.send_command(0x18);
+        epdconfig.send_data(0X80);
+        epdconfig.send_command(0x22);
+        epdconfig.send_data(0XB1);	#Load Temperature and waveform setting.
+        epdconfig.send_command(0x20);
         self.ReadBusy();        #waiting for the electronic paper IC to release the idle signal
 
-        self.send_command(0x4E); 
-        self.send_data(0x00);
-        self.send_data(0x00);
-        self.send_command(0x4F); 
-        self.send_data(0xAF);
-        self.send_data(0x02);
+        epdconfig.send_command(0x4E); 
+        epdconfig.send_data(0x00);
+        epdconfig.send_data(0x00);
+        epdconfig.send_command(0x4F); 
+        epdconfig.send_data(0xAF);
+        epdconfig.send_data(0x02);
         
         return 0
 
@@ -159,46 +135,46 @@ class EPD:
         return buf
 
     def display(self, imageblack, imagered):
-        self.send_command(0x4F); 
-        self.send_data(0xAf);
+        epdconfig.send_command(0x4F); 
+        epdconfig.send_data(0xAf);
         
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(imageblack[i]);
+            epdconfig.send_data(imageblack[i]);
         
         
-        self.send_command(0x26)
+        epdconfig.send_command(0x26)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(~imagered[i]);
+            epdconfig.send_data(~imagered[i]);
         
-        self.send_command(0x22);
-        self.send_data(0xC7);    #Load LUT from MCU(0x32)
-        self.send_command(0x20);
+        epdconfig.send_command(0x22);
+        epdconfig.send_data(0xC7);    #Load LUT from MCU(0x32)
+        epdconfig.send_command(0x20);
         epdconfig.delay_ms(200);      #!!!The delay here is necessary, 200uS at least!!!     
         self.ReadBusy();
         
     def Clear(self):
-        self.send_command(0x4F); 
-        self.send_data(0xAf);
+        epdconfig.send_command(0x4F); 
+        epdconfig.send_data(0xAf);
         
-        self.send_command(0x24)
+        epdconfig.send_command(0x24)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xff);
+            epdconfig.send_data(0xff);
         
         
-        self.send_command(0x26)
+        epdconfig.send_command(0x26)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00);
+            epdconfig.send_data(0x00);
         
-        self.send_command(0x22);
-        self.send_data(0xC7);    #Load LUT from MCU(0x32)
-        self.send_command(0x20);
+        epdconfig.send_command(0x22);
+        epdconfig.send_data(0xC7);    #Load LUT from MCU(0x32)
+        epdconfig.send_command(0x20);
         epdconfig.delay_ms(200);      #!!!The delay here is necessary, 200uS at least!!!     
         self.ReadBusy();
 
     def sleep(self):
-        self.send_command(0x10);  	#deep sleep
-        self.send_data(0x01);
+        epdconfig.send_command(0x10);  	#deep sleep
+        epdconfig.send_data(0x01);
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5b_V2.py
@@ -37,40 +37,16 @@ EPD_HEIGHT      = 480
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
-        self.height = EPD_HEIGHT
-
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(4)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
+        self.height = EPD_HEIGHT 
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
-        self.send_command(0x71)
+        epdconfig.send_command(0x71)
         busy = epdconfig.digital_read(self.busy_pin)
         while(busy == 0):
-            self.send_command(0x71)
+            epdconfig.send_command(0x71)
             busy = epdconfig.digital_read(self.busy_pin)
         epdconfig.delay_ms(200)
             
@@ -78,42 +54,42 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
             
-        self.reset()
+        epdconfig.reset(200, 4, 200)
         
-        self.send_command(0x01);			#POWER SETTING
-        self.send_data(0x07);
-        self.send_data(0x07);    #VGH=20V,VGL=-20V
-        self.send_data(0x3f);		#VDH=15V
-        self.send_data(0x3f);		#VDL=-15V
+        epdconfig.send_command(0x01);			#POWER SETTING
+        epdconfig.send_data(0x07);
+        epdconfig.send_data(0x07);    #VGH=20V,VGL=-20V
+        epdconfig.send_data(0x3f);		#VDH=15V
+        epdconfig.send_data(0x3f);		#VDL=-15V
 
-        self.send_command(0x04); #POWER ON
+        epdconfig.send_command(0x04); #POWER ON
         epdconfig.delay_ms(100);
         self.ReadBusy();
 
-        self.send_command(0X00);			#PANNEL SETTING
-        self.send_data(0x0F);   #KW-3f   KWR-2F	BWROTP 0f	BWOTP 1f
+        epdconfig.send_command(0X00);			#PANNEL SETTING
+        epdconfig.send_data(0x0F);   #KW-3f   KWR-2F	BWROTP 0f	BWOTP 1f
 
-        self.send_command(0x61);        	#tres
-        self.send_data(0x03);		#source 800
-        self.send_data(0x20);
-        self.send_data(0x01);		#gate 480
-        self.send_data(0xE0);
+        epdconfig.send_command(0x61);        	#tres
+        epdconfig.send_data(0x03);		#source 800
+        epdconfig.send_data(0x20);
+        epdconfig.send_data(0x01);		#gate 480
+        epdconfig.send_data(0xE0);
 
-        self.send_command(0X15);
-        self.send_data(0x00);
+        epdconfig.send_command(0X15);
+        epdconfig.send_data(0x00);
 
-        self.send_command(0X50);			#VCOM AND DATA INTERVAL SETTING
-        self.send_data(0x11);
-        self.send_data(0x07);
+        epdconfig.send_command(0X50);			#VCOM AND DATA INTERVAL SETTING
+        epdconfig.send_data(0x11);
+        epdconfig.send_data(0x07);
 
-        self.send_command(0X60);			#TCON SETTING
-        self.send_data(0x22);
+        epdconfig.send_command(0X60);			#TCON SETTING
+        epdconfig.send_data(0x22);
 
-        self.send_command(0x65);
-        self.send_data(0x00);
-        self.send_data(0x00);
-        self.send_data(0x00);
-        self.send_data(0x00);
+        epdconfig.send_command(0x65);
+        epdconfig.send_data(0x00);
+        epdconfig.send_data(0x00);
+        epdconfig.send_data(0x00);
+        epdconfig.send_data(0x00);
     
         return 0
 
@@ -142,37 +118,37 @@ class EPD:
         return buf
 
     def display(self, imageblack, imagered):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(imageblack[i]);
+            epdconfig.send_data(imageblack[i]);
         
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(~imagered[i]);
+            epdconfig.send_data(~imagered[i]);
         
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(100)
         self.ReadBusy()
         
     def Clear(self):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xff)
+            epdconfig.send_data(0xff)
             
-        self.send_command(0x13)
+        epdconfig.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
+            epdconfig.send_data(0x00)
                 
-        self.send_command(0x12)
+        epdconfig.send_command(0x12)
         epdconfig.delay_ms(100)
         self.ReadBusy()
 
     def sleep(self):
-        self.send_command(0x02) # POWER_OFF
+        epdconfig.send_command(0x02) # POWER_OFF
         self.ReadBusy()
         
-        self.send_command(0x07) # DEEP_SLEEP
-        self.send_data(0XA5)
+        epdconfig.send_command(0x07) # DEEP_SLEEP
+        epdconfig.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5bc.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5bc.py
@@ -37,33 +37,9 @@ EPD_HEIGHT      = 384
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdconfig.RST_PIN
-        self.dc_pin = epdconfig.DC_PIN
         self.busy_pin = epdconfig.BUSY_PIN
-        self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
-
-    # Hardware reset
-    def reset(self):
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200) 
-        epdconfig.digital_write(self.reset_pin, 0)
-        epdconfig.delay_ms(5)
-        epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(200)   
-
-    def send_command(self, command):
-        epdconfig.digital_write(self.dc_pin, 0)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([command])
-        epdconfig.digital_write(self.cs_pin, 1)
-
-    def send_data(self, data):
-        epdconfig.digital_write(self.dc_pin, 1)
-        epdconfig.digital_write(self.cs_pin, 0)
-        epdconfig.spi_writebyte([data])
-        epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
         logging.debug("e-Paper busy")
@@ -75,44 +51,44 @@ class EPD:
         if (epdconfig.module_init() != 0):
             return -1
             
-        self.reset()
+        epdconfig.reset(200, 5, 200)
 
-        self.send_command(0x01) # POWER_SETTING
-        self.send_data(0x37)
-        self.send_data(0x00)
+        epdconfig.send_command(0x01) # POWER_SETTING
+        epdconfig.send_data(0x37)
+        epdconfig.send_data(0x00)
         
-        self.send_command(0x00) # PANEL_SETTING
-        self.send_data(0xCF)
-        self.send_data(0x08)
+        epdconfig.send_command(0x00) # PANEL_SETTING
+        epdconfig.send_data(0xCF)
+        epdconfig.send_data(0x08)
         
-        self.send_command(0x30) # PLL_CONTROL
-        self.send_data(0x3A) # PLL:  0-15:0x3C, 15+:0x3A
+        epdconfig.send_command(0x30) # PLL_CONTROL
+        epdconfig.send_data(0x3A) # PLL:  0-15:0x3C, 15+:0x3A
         
-        self.send_command(0x82) # VCM_DC_SETTING
-        self.send_data(0x28) #all temperature  range
+        epdconfig.send_command(0x82) # VCM_DC_SETTING
+        epdconfig.send_data(0x28) #all temperature  range
 
-        self.send_command(0x06) # BOOSTER_SOFT_START
-        self.send_data(0xc7)
-        self.send_data(0xcc)
-        self.send_data(0x15)
+        epdconfig.send_command(0x06) # BOOSTER_SOFT_START
+        epdconfig.send_data(0xc7)
+        epdconfig.send_data(0xcc)
+        epdconfig.send_data(0x15)
 
-        self.send_command(0x50) # VCOM AND DATA INTERVAL SETTING
-        self.send_data(0x77)
+        epdconfig.send_command(0x50) # VCOM AND DATA INTERVAL SETTING
+        epdconfig.send_data(0x77)
 
-        self.send_command(0x60) # TCON_SETTING
-        self.send_data(0x22)
+        epdconfig.send_command(0x60) # TCON_SETTING
+        epdconfig.send_data(0x22)
 
-        self.send_command(0x65) # FLASH CONTROL
-        self.send_data(0x00)
+        epdconfig.send_command(0x65) # FLASH CONTROL
+        epdconfig.send_data(0x00)
 
-        self.send_command(0x61) # TCON_RESOLUTION
-        self.send_data(self.width >> 8) # source 640
-        self.send_data(self.width & 0xff)
-        self.send_data(self.height >> 8) # gate 384
-        self.send_data(self.height & 0xff)
+        epdconfig.send_command(0x61) # TCON_RESOLUTION
+        epdconfig.send_data(self.width >> 8) # source 640
+        epdconfig.send_data(self.width & 0xff)
+        epdconfig.send_data(self.height >> 8) # gate 384
+        epdconfig.send_data(self.height & 0xff)
 
-        self.send_command(0xe5) # FLASH MODE
-        self.send_data(0x03)
+        epdconfig.send_command(0xe5) # FLASH MODE
+        epdconfig.send_data(0x03)
         
         return 0
 
@@ -141,7 +117,7 @@ class EPD:
         return buf
 
     def display(self, imageblack, imagered):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width / 8 * self.height)):
             temp1 = imageblack[i]
             temp2 = imagered[i]
@@ -166,35 +142,35 @@ class EPD:
                     temp3 |= 0x03              #white
                 temp1 = (temp1 << 1) & 0xFF
                 temp2 = (temp2 << 1) & 0xFF
-                self.send_data(temp3)
+                epdconfig.send_data(temp3)
                 j += 1
                 
-        self.send_command(0x04) # POWER ON
+        epdconfig.send_command(0x04) # POWER ON
         self.ReadBusy()
-        self.send_command(0x12) # display refresh
+        epdconfig.send_command(0x12) # display refresh
         epdconfig.delay_ms(100)
         self.ReadBusy()
         
     def Clear(self):
-        self.send_command(0x10)
+        epdconfig.send_command(0x10)
         for i in range(0, int(self.width / 8 * self.height)):
-            self.send_data(0x33)
-            self.send_data(0x33)
-            self.send_data(0x33)
-            self.send_data(0x33)
+            epdconfig.send_data(0x33)
+            epdconfig.send_data(0x33)
+            epdconfig.send_data(0x33)
+            epdconfig.send_data(0x33)
             
-        self.send_command(0x04) # POWER ON
+        epdconfig.send_command(0x04) # POWER ON
         self.ReadBusy()
-        self.send_command(0x12) # display refresh
+        epdconfig.send_command(0x12) # display refresh
         epdconfig.delay_ms(100)
         self.ReadBusy()
 
     def sleep(self):
-        self.send_command(0x02) # POWER_OFF
+        epdconfig.send_command(0x02) # POWER_OFF
         self.ReadBusy()
         
-        self.send_command(0x07) # DEEP_SLEEP
-        self.send_data(0XA5)
+        epdconfig.send_command(0x07) # DEEP_SLEEP
+        epdconfig.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -56,12 +56,6 @@ class RaspberryPi:
     def delay_ms(self, delaytime):
         time.sleep(delaytime / 1000.0)
 
-    def spi_writebyte(self, data):
-        self.SPI.writebytes(data)
-
-    def spi_writebyte2(self, data):
-        self.SPI.writebytes2(data)
-
     def module_init(self):
         self.GPIO.setmode(self.GPIO.BCM)
         self.GPIO.setwarnings(False)
@@ -85,7 +79,32 @@ class RaspberryPi:
         self.GPIO.output(self.DC_PIN, 0)
 
         self.GPIO.cleanup()
+    
+    def reset(self, delay_a, delay_b, delay_c):
+        self.GPIO.output(self.RST_PIN, 1)
+        self.delay_ms(delay_a) 
+        self.GPIO.output(self.RST_PIN, 0)
+        self.delay_ms(delay_b)
+        self.GPIO.output(self.RST_PIN, 1)
+        self.delay_ms(delay_c)   
 
+    def send_command(self, command):
+        self.GPIO.output(self.DC_PIN, 0)
+        self.GPIO.output(self.CS_PIN, 0)
+        self.SPI.writebytes([command])
+        self.GPIO.output(self.CS_PIN, 1)
+
+    def send_data(self, data):
+        self.GPIO.output(self.DC_PIN, 1)
+        self.GPIO.output(self.CS_PIN, 0)
+        self.SPI.writebytes([data])
+        self.GPIO.output(self.CS_PIN, 1)
+        
+    def send_data2(self, data):
+        self.GPIO.output(self.DC_PIN, 1)
+        self.GPIO.output(self.CS_PIN, 0)
+        self.SPI.writebytes2(data)
+        self.GPIO.output(self.CS_PIN, 1)
 
 class JetsonNano:
     # Pin definition
@@ -122,9 +141,6 @@ class JetsonNano:
     def delay_ms(self, delaytime):
         time.sleep(delaytime / 1000.0)
 
-    def spi_writebyte(self, data):
-        self.SPI.SYSFS_software_spi_transfer(data[0])
-
     def module_init(self):
         self.GPIO.setmode(self.GPIO.BCM)
         self.GPIO.setwarnings(False)
@@ -144,7 +160,26 @@ class JetsonNano:
         self.GPIO.output(self.DC_PIN, 0)
 
         self.GPIO.cleanup()
+        
+    def reset(self):
+        self.GPIO.output(self.reset_pin, 1)
+        self.delay_ms(200) 
+        self.GPIO.output(self.reset_pin, 0)
+        self.delay_ms(2)
+        self.GPIO.output(self.reset_pin, 1)
+        self.delay_ms(200)   
 
+    def send_command(self, command):
+        self.GPIO.output(self.dc_pin, 0)
+        self.GPIO.output(self.cs_pin, 0)
+        self.SPI.SYSFS_software_spi_transfer(command)
+        self.GPIO.output(self.cs_pin, 1)
+
+    def send_data(self, data):
+        self.GPIO.output(self.dc_pin, 1)
+        self.GPIO.output(self.cs_pin, 0)
+        self.SPI.SYSFS_software_spi_transfer(data)
+        self.GPIO.output(self.cs_pin, 1)
 
 if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835'):
     implementation = RaspberryPi()


### PR DESCRIPTION
The same `reset()`, `send_command()`, and `send_data()` functions are present in every driver. This moves them to `epdconfig.py`.

I'm not sure why the timings in `reset()` differ between drivers, or if they even need to be any specific values (the datasheets don't mention it) so for now I've made them parameters. So, for example, if the reset function in a driver was...
```
def reset(self):
    epdconfig.digital_write(self.reset_pin, 1)
    epdconfig.delay_ms(200)
    epdconfig.digital_write(self.reset_pin, 0)
    epdconfig.delay_ms(2)
    epdconfig.digital_write(self.reset_pin, 1)
    epdconfig.delay_ms(200)
```
...calls to `self.reset()` become `epdconfig.reset(200, 2, 200)`. This may be unnecessary, if the same values can be used for all drivers.