### PR TITLE
Improve performance of the EPD 5.65 inch color E Ink when using Python

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in65f.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in65f.py
@@ -141,11 +141,20 @@ class EPD:
 
     def getbuffer(self, image):
         # Create a pallette with the 7 colors supported by the panel
-        pal_image= Image.new("P", (1,1))
+        pal_image = Image.new("P", (1,1))
         pal_image.putpalette( (0,0,0,  255,255,255,  0,255,0,   0,0,255,  255,0,0,  255,255,0, 255,128,0) + (0,0,0)*249)
 
+        # Check if we need to rotate the image
+        imwidth, imheight = image.size
+        if(imwidth == self.width and imheight == self.height):
+            image_temp = image
+        elif(imwidth == self.height and imheight == self.width):
+            image_temp = image.rotate(90, expand=True)
+        else:
+            logging.warning("Invalid image dimensions: %d x %d, expected %d x %d" % (imwidth, imheight, self.width, self.height))
+
         # Convert the soruce image to the 7 colors, dithering if needed
-        image_7color = image.convert("RGB").quantize(palette=pal_image)
+        image_7color = image_temp.convert("RGB").quantize(palette=pal_image)
         buf_7color = bytearray(image_7color.tobytes('raw'))
 
         # PIL does not support 4 bit color, so pack the 4 bits of color

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in65f.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in65f.py
@@ -32,6 +32,10 @@
 import logging
 from . import epdconfig
 
+import PIL
+from PIL import Image
+import io
+
 # Display resolution
 EPD_WIDTH       = 600
 EPD_HEIGHT      = 448
@@ -51,12 +55,12 @@ class EPD:
         self.RED    = 0x0000ff   #   0100
         self.YELLOW = 0x00ffff   #   0101
         self.ORANGE = 0x0080ff   #   0110
-        
-        
+
+
     # Hardware reset
     def reset(self):
         epdconfig.digital_write(self.reset_pin, 1)
-        epdconfig.delay_ms(600) 
+        epdconfig.delay_ms(600)
         epdconfig.digital_write(self.reset_pin, 0)
         epdconfig.delay_ms(2)
         epdconfig.digital_write(self.reset_pin, 1)
@@ -73,25 +77,31 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 0)
         epdconfig.spi_writebyte([data])
         epdconfig.digital_write(self.cs_pin, 1)
-        
+
+    def send_data_bulk(self, data):
+        epdconfig.digital_write(self.dc_pin, 1)
+        epdconfig.digital_write(self.cs_pin, 0)
+        epdconfig.spi_writebyte2(data)
+        epdconfig.digital_write(self.cs_pin, 1)
+
     def ReadBusyHigh(self):
         logging.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
-            epdconfig.delay_ms(100)    
+            epdconfig.delay_ms(100)
         logging.debug("e-Paper busy release")
-        
+
     def ReadBusyLow(self):
         logging.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 1):      # 0: idle, 1: busy
-            epdconfig.delay_ms(100)    
+            epdconfig.delay_ms(100)
         logging.debug("e-Paper busy release")
-        
+
     def init(self):
         if (epdconfig.module_init() != 0):
             return -1
         # EPD hardware init start
         self.reset()
-        
+
         self.ReadBusyHigh()
         self.send_command(0x00)
         self.send_data(0xEF)
@@ -122,7 +132,7 @@ class EPD:
         self.send_data(0xC0)
         self.send_command(0xE3)
         self.send_data(0xAA)
-        
+
         epdconfig.delay_ms(100)
         self.send_command(0x50)
         self.send_data(0x37)
@@ -130,102 +140,58 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
+        # Create a pallette with the 7 colors supported by the panel
+        pal_image= Image.new("P", (1,1))
+        pal_image.putpalette( (0,0,0,  255,255,255,  0,255,0,   0,0,255,  255,0,0,  255,255,0, 255,128,0) + (0,0,0)*249)
+
+        # Convert the soruce image to the 7 colors, dithering if needed
+        image_7color = image.convert("RGB").quantize(palette=pal_image)
+        buf_7color = bytearray(image_7color.tobytes('raw'))
+
+        # PIL does not support 4 bit color, so pack the 4 bits of color
+        # into a single byte to transfer to the panel
         buf = [0x00] * int(self.width * self.height / 2)
-        image_monocolor = image.convert('RGB')#Picture mode conversion
-        imwidth, imheight = image_monocolor.size
-        pixels = image_monocolor.load()
-        logging.debug('imwidth = %d  imheight =  %d ',imwidth, imheight)
-        if(imwidth == self.width and imheight == self.height):
-            for y in range(imheight):
-                for x in range(imwidth):
-                    # Set the bits for the column of pixels at the current position.
-                    Add = int((x + y * self.width) / 2)
-                    Color = 0;
-                    if (pixels[x, y][0] == 0 and  pixels[x, y][1] == 0 and pixels[x, y][2] == 0):
-                        Color = 0
-                    elif (pixels[x, y][0] == 255 and  pixels[x, y][1] == 255 and pixels[x, y][2] == 255):
-                        Color = 1
-                    elif (pixels[x, y][0] == 0 and  pixels[x, y][1] == 255 and pixels[x, y][2] == 0):
-                        Color = 2
-                    elif (pixels[x, y][0] == 0 and  pixels[x, y][1] == 0 and pixels[x, y][2] == 255):
-                        Color = 3
-                    elif (pixels[x, y][0] == 255 and  pixels[x, y][1] == 0 and pixels[x, y][2] == 0):
-                        Color = 4
-                    elif (pixels[x, y][0] == 255 and  pixels[x, y][1] == 255 and pixels[x, y][2] == 0):
-                        Color = 5
-                    elif (pixels[x, y][0] == 255 and  pixels[x, y][1] == 128 and pixels[x, y][2] == 0):
-                        Color = 6
-                    
-                    data_t = buf[Add]&(~(0xF0 >> ((x % 2)*4)))
-                    buf[Add] = data_t | ((Color << 4) >> ((x % 2)*4));
-                        
-        elif(imwidth == self.height and imheight == self.width):
-            for y in range(imheight):
-                for x in range(imwidth):
-                    newx = y
-                    newy = self.height - x - 1   
-                    Add = int((newx + newy*self.width) / 2)
-                    Color = 0;
-                    if (pixels[x, y][0] == 0 and  pixels[x, y][1] == 0 and pixels[x, y][2] == 0):
-                        Color = 0
-                    elif (pixels[x, y][0] == 255 and  pixels[x, y][1] == 255 and pixels[x, y][2] == 255):
-                        Color = 1
-                    elif (pixels[x, y][0] == 0 and  pixels[x, y][1] == 255 and pixels[x, y][2] == 0):
-                        Color = 2
-                    elif (pixels[x, y][0] == 0 and  pixels[x, y][1] == 0 and pixels[x, y][2] == 255):
-                        Color = 3
-                    elif (pixels[x, y][0] == 255 and  pixels[x, y][1] == 0 and pixels[x, y][2] == 0):
-                        Color = 4
-                    elif (pixels[x, y][0] == 255 and  pixels[x, y][1] == 255 and pixels[x, y][2] == 0):
-                        Color = 5
-                    elif (pixels[x, y][0] == 255 and  pixels[x, y][1] == 128 and pixels[x, y][2] == 0):
-                        Color = 6
-                    
-                    data_t = buf[Add]&(~(0xF0 >> ((newx % 2)*4)))
-                    buf[Add] = data_t | ((Color << 4) >> ((newx % 2)*4));
+        idx = 0
+        for i in range(0, len(buf_7color), 2):
+            buf[idx] = (buf_7color[i] << 4) + buf_7color[i+1]
+            idx += 1
+
         return buf
 
     def display(self,image):
-        self.send_command(0x61)#Set Resolution setting
+        self.send_command(0x61) #Set Resolution setting
         self.send_data(0x02)
         self.send_data(0x58)
         self.send_data(0x01)
         self.send_data(0xC0)
         self.send_command(0x10)
-        for i in range(0, int(EPD_HEIGHT)):
-            for j in range(0, int(EPD_WIDTH/2)):
-                self.send_data((image[j+(int(EPD_WIDTH/2)*i)]))
-        self.send_command(0x04)#0x04
+
+        self.send_data_bulk(image)
+        self.send_command(0x04) #0x04
         self.ReadBusyHigh()
-        self.send_command(0x12)#0x12
+        self.send_command(0x12) #0x12
         self.ReadBusyHigh()
-        self.send_command(0x02)  #0x02
+        self.send_command(0x02) #0x02
         self.ReadBusyLow()
         epdconfig.delay_ms(500)
-        
+
     def Clear(self):
-        self.send_command(0x61)#Set Resolution setting
+        self.send_command(0x61) #Set Resolution setting
         self.send_data(0x02)
         self.send_data(0x58)
         self.send_data(0x01)
         self.send_data(0xC0)
         self.send_command(0x10)
-        for i in range(0, int(EPD_HEIGHT)):
-            for j in range(0, int(EPD_WIDTH/2)):
-                self.send_data(0x11)
-        #BLACK   0x00    /// 0000
-        #WHITE   0x11    /// 0001
-        #GREEN   0x22    /// 0010
-        #BLUE    0x33    /// 0011
-        #RED     0x44    /// 0100
-        #YELLOW  0x55    /// 0101
-        #ORANGE  0x66    /// 0110
-        #CLEAN   0x77    /// 0111   unavailable  Afterimage
-        self.send_command(0x04)#0x04
+
+        # Set all pixels to white
+        buf = [0x11] * int(self.width * self.height / 2)
+        self.send_data_bulk(buf)
+
+        self.send_command(0x04) #0x04
         self.ReadBusyHigh()
-        self.send_command(0x12)#0x12
+        self.send_command(0x12) #0x12
         self.ReadBusyHigh()
-        self.send_command(0x02)  #0x02
+        self.send_command(0x02) #0x02
         self.ReadBusyLow()
         epdconfig.delay_ms(500)
 
@@ -236,5 +202,4 @@ class EPD:
         epdconfig.digital_write(self.reset_pin, 0)
 
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit() 
-        
+        epdconfig.module_exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in65f.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in65f.py
@@ -119,7 +119,7 @@ class EPD:
         self.send_data(0x1D)
         self.send_command(0x30)
         self.send_data(0x3c)
-        self.send_command(0x40)
+        self.send_command(0x41)
         self.send_data(0x00)
         self.send_command(0x50)
         self.send_data(0x37)


### PR DESCRIPTION
Based on the great work from @dbrant in accelerating drawing.  The highlights of the change are:

- Transfer pixel data as a bulk transfer, using the `SPI.writebytes2()` function.
- Use Pillow to quantize the input image using the 7 color palette that panel supports.  As a bonus, arbitrary images can be drawn without formatting them for the panel.
- Access the bytes of the image using `tobytes('raw')` before packing the 4-bit colors into a single byte.
- Clean up some whitespace.

Using the existing demo code as an example running in the following environment, the runtime is greatly reduced.

Hardware:
`Raspberry Pi Zero W`
OS:
`Raspbian GNU/Linux 10 (buster)`
Software:
`Python 3.7.3`


Original:
```
python3 epd_5in65f_test.py
real	6m41.861s
user	3m4.695s
sys	1m5.113s
```

Using branch `epd5in65f_performance_python`:
```
python3 epd_5in65f_test.py
real	2m7.643s
user	0m6.746s
sys	0m0.368s
```

Further improvement are possible too, removing or tightening up `sleep()` calls and moving all multi-byte SPI transactions to `SPI.writebytes2()`.  