### PR TITLE
Mirrored text display in 4Gray Horizontal Display 

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7.py
@@ -410,7 +410,7 @@ class EPD:
             for x in range(imwidth):
                 for y in range(imheight):
                     newx = y
-                    newy = x
+                    newy = self.height - x - 1
                     if(pixels[x, y] == 0xC0):
                         pixels[x, y] = 0x80
                     elif (pixels[x, y] == 0x80):


### PR DESCRIPTION
Hello,

Root cause of issue as explained in #156.  - The issue occurs when horizontal layout is rendered in 4Gray mode. Due to an incorrect coordinates calculation the text is always displayed in mirror layout. This affects both new image or open image. 

Added the implementation. Tested with both new and open images.

![IMG_20210417_211908](https://user-images.githubusercontent.com/7939779/115118814-b9867280-9fc2-11eb-967e-8b0c02822a38.jpg)
 