### PR TITLE
Improve C library performance for 2in13 V2

### DIFF
--- a/RaspberryPi_JetsonNano/c/Makefile
+++ b/RaspberryPi_JetsonNano/c/Makefile
@@ -10,9 +10,6 @@ OBJ_O = $(patsubst %.c,${DIR_BIN}/%.o,$(notdir ${OBJ_C}))
 RPI_DEV_C = $(wildcard $(DIR_BIN)/dev_hardware_SPI.o $(DIR_BIN)/RPI_sysfs_gpio.o $(DIR_BIN)/DEV_Config.o )
 JETSON_DEV_C = $(wildcard $(DIR_BIN)/sysfs_software_spi.o $(DIR_BIN)/sysfs_gpio.o $(DIR_BIN)/DEV_Config.o )
 
-
-DEBUG = -D DEBUG
-
 # USELIB_RPI = USE_BCM2835_LIB
 USELIB_RPI = USE_WIRINGPI_LIB
 # USELIB_RPI = USE_DEV_LIB
@@ -43,7 +40,7 @@ JETSON: JETSON_DEV JETSON_epd
 
 TARGET = epd
 CC = gcc
-MSG = -g -O -ffunction-sections -fdata-sections -Wall
+MSG = -g -O3 -ffunction-sections -fdata-sections -Wall
 CFLAGS += $(MSG)
 
 RPI_epd:${OBJ_O}

--- a/RaspberryPi_JetsonNano/c/lib/Config/DEV_Config.c
+++ b/RaspberryPi_JetsonNano/c/lib/Config/DEV_Config.c
@@ -206,7 +206,7 @@ static int DEV_Equipment_Testing(void)
 	int fd;
 	char value_str[20];
 	fd = open("/etc/issue", O_RDONLY);
-    printf("Current environment: ");
+    Debug("Current environment: ");
 	while(1) {
 		if (fd < 0) {
 			Debug( "Read failed Pin\n");
@@ -218,21 +218,21 @@ static int DEV_Equipment_Testing(void)
 				return -1;
 			}
 			if(value_str[i] ==32) {
-				printf("\r\n");
+				Debug("\r\n");
 				break;
 			}
-			printf("%c",value_str[i]);
+			Debug("%c",value_str[i]);
 		}
 		break;
 	}
 #ifdef RPI
 	if(i<5) {
-		printf("Unrecognizable\r\n");
+		Debug("Unrecognizable\r\n");
 	} else {
 		char RPI_System[10]   = {"Raspbian"};
 		for(i=0; i<6; i++) {
 			if(RPI_System[i]!= value_str[i]) {
-				printf("Please make JETSON !!!!!!!!!!\r\n");
+				Debug("Please make JETSON !!!!!!!!!!\r\n");
 				return -1;
 			}
 		}
@@ -245,7 +245,7 @@ static int DEV_Equipment_Testing(void)
 		char JETSON_System[10]= {"Ubuntu"};
 		for(i=0; i<6; i++) {
 			if(JETSON_System[i]!= value_str[i] ) {
-				printf("Please make RPI !!!!!!!!!!\r\n");
+				Debug("Please make RPI !!!!!!!!!!\r\n");
 				return -1;
 			}
 		}
@@ -284,17 +284,17 @@ Info:
 ******************************************************************************/
 UBYTE DEV_Module_Init(void)
 {
-    printf("/***********************************/ \r\n");
+    Debug("/***********************************/ \r\n");
 	if(DEV_Equipment_Testing() < 0) {
 		return 1;
 	}
 #ifdef RPI
 #ifdef USE_BCM2835_LIB
 	if(!bcm2835_init()) {
-		printf("bcm2835 init failed  !!! \r\n");
+		Debug("bcm2835 init failed  !!! \r\n");
 		return 1;
 	} else {
-		printf("bcm2835 init success !!! \r\n");
+		Debug("bcm2835 init success !!! \r\n");
 	}
 
 	// GPIO Config
@@ -310,10 +310,10 @@ UBYTE DEV_Module_Init(void)
 #elif USE_WIRINGPI_LIB
 	//if(wiringPiSetup() < 0)//use wiringpi Pin number table
 	if(wiringPiSetupGpio() < 0) { //use BCM2835 Pin number table
-		printf("set wiringPi lib failed	!!! \r\n");
+		Debug("set wiringPi lib failed	!!! \r\n");
 		return 1;
 	} else {
-		printf("set wiringPi lib success !!! \r\n");
+		Debug("set wiringPi lib success !!! \r\n");
 	}
 
 	// GPIO Config
@@ -321,7 +321,7 @@ UBYTE DEV_Module_Init(void)
 	wiringPiSPISetup(0,10000000);
 	// wiringPiSPISetupMode(0, 32000000, 0);
 #elif USE_DEV_LIB
-	printf("Write and read /dev/spidev0.0 \r\n");
+	Debug("Write and read /dev/spidev0.0 \r\n");
 	DEV_GPIO_Init();
 	DEV_HARDWARE_SPI_begin("/dev/spidev0.0");
     DEV_HARDWARE_SPI_setSpeed(10000000);
@@ -330,19 +330,19 @@ UBYTE DEV_Module_Init(void)
 #elif JETSON
 #ifdef USE_DEV_LIB
 	DEV_GPIO_Init();
-	printf("Software spi\r\n");
+	Debug("Software spi\r\n");
 	SYSFS_software_spi_begin();
 	SYSFS_software_spi_setBitOrder(SOFTWARE_SPI_MSBFIRST);
 	SYSFS_software_spi_setDataMode(SOFTWARE_SPI_Mode0);
 	SYSFS_software_spi_setClockDivider(SOFTWARE_SPI_CLOCK_DIV4);
 #elif USE_HARDWARE_LIB
-	printf("Write and read /dev/spidev0.0 \r\n");
+	Debug("Write and read /dev/spidev0.0 \r\n");
 	DEV_GPIO_Init();
 	DEV_HARDWARE_SPI_begin("/dev/spidev0.0");
 #endif
 
 #endif
-    printf("/***********************************/ \r\n");
+    Debug("/***********************************/ \r\n");
 	return 0;
 }
 

--- a/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_2in13_V2.c
+++ b/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_2in13_V2.c
@@ -129,6 +129,19 @@ static void EPD_2IN13_V2_SendData(UBYTE Data)
 }
 
 /******************************************************************************
+function :	send data
+parameter:
+    Data : Write data
+******************************************************************************/
+static void EPD_2IN13_V2_SendData_nByte(uint8_t *pData, uint32_t len)
+{
+    DEV_Digital_Write(EPD_DC_PIN, 1);
+    DEV_Digital_Write(EPD_CS_PIN, 0);
+    DEV_SPI_Write_nByte(pData, len);
+    DEV_Digital_Write(EPD_CS_PIN, 1);
+}
+
+/******************************************************************************
 function :	Wait until the busy_pin goes LOW
 parameter:
 ******************************************************************************/
@@ -170,8 +183,9 @@ parameter:
 ******************************************************************************/
 void EPD_2IN13_V2_Init(UBYTE Mode)
 {
-    UBYTE count;
     EPD_2IN13_V2_Reset();
+
+    uint8_t data[7];
 
     if(Mode == EPD_2IN13_V2_FULL) {
         EPD_2IN13_V2_ReadBusy();
@@ -183,23 +197,26 @@ void EPD_2IN13_V2_Init(UBYTE Mode)
         EPD_2IN13_V2_SendCommand(0x7E); //set digital block control
         EPD_2IN13_V2_SendData(0x3B);
 
+        data[0] = 0xF9;
+        data[1] = 0x00;
+        data[2] = 0x00;
         EPD_2IN13_V2_SendCommand(0x01); //Driver output control
-        EPD_2IN13_V2_SendData(0xF9);
-        EPD_2IN13_V2_SendData(0x00);
-        EPD_2IN13_V2_SendData(0x00);
+        EPD_2IN13_V2_SendData_nByte(&data[0], 3);
 
         EPD_2IN13_V2_SendCommand(0x11); //data entry mode
         EPD_2IN13_V2_SendData(0x01);
 
+        data[0] = 0x00;
+        data[1] = 0x0F;
         EPD_2IN13_V2_SendCommand(0x44); //set Ram-X address start/end position
-        EPD_2IN13_V2_SendData(0x00);
-        EPD_2IN13_V2_SendData(0x0F);    //0x0C-->(15+1)*8=128
+        EPD_2IN13_V2_SendData_nByte(&data[0], 2);
 
+        data[0] = 0xF9;
+        data[1] = 0x00;
+        data[2] = 0x00;
+        data[3] = 0x00;
         EPD_2IN13_V2_SendCommand(0x45); //set Ram-Y address start/end position
-        EPD_2IN13_V2_SendData(0xF9);   //0xF9-->(249+1)=250
-        EPD_2IN13_V2_SendData(0x00);
-        EPD_2IN13_V2_SendData(0x00);
-        EPD_2IN13_V2_SendData(0x00);
+        EPD_2IN13_V2_SendData_nByte(&data[0], 4);
 
         EPD_2IN13_V2_SendCommand(0x3C); //BorderWavefrom
         EPD_2IN13_V2_SendData(0x03);
@@ -210,10 +227,11 @@ void EPD_2IN13_V2_Init(UBYTE Mode)
         EPD_2IN13_V2_SendCommand(0x03);
         EPD_2IN13_V2_SendData(EPD_2IN13_V2_lut_full_update[70]);
 
+        data[0] = EPD_2IN13_V2_lut_full_update[71];
+        data[1] = EPD_2IN13_V2_lut_full_update[72];
+        data[2] = EPD_2IN13_V2_lut_full_update[73];
         EPD_2IN13_V2_SendCommand(0x04); //
-        EPD_2IN13_V2_SendData(EPD_2IN13_V2_lut_full_update[71]);
-        EPD_2IN13_V2_SendData(EPD_2IN13_V2_lut_full_update[72]);
-        EPD_2IN13_V2_SendData(EPD_2IN13_V2_lut_full_update[73]);
+        EPD_2IN13_V2_SendData_nByte(&data[0], 3);
 
         EPD_2IN13_V2_SendCommand(0x3A);     //Dummy Line
         EPD_2IN13_V2_SendData(EPD_2IN13_V2_lut_full_update[74]);
@@ -221,15 +239,14 @@ void EPD_2IN13_V2_Init(UBYTE Mode)
         EPD_2IN13_V2_SendData(EPD_2IN13_V2_lut_full_update[75]);
 
         EPD_2IN13_V2_SendCommand(0x32);
-        for(count = 0; count < 70; count++) {
-            EPD_2IN13_V2_SendData(EPD_2IN13_V2_lut_full_update[count]);
-        }
+        EPD_2IN13_V2_SendData_nByte((uint8_t*)&EPD_2IN13_V2_lut_full_update[0], 70);
 
         EPD_2IN13_V2_SendCommand(0x4E);   // set RAM x address count to 0;
         EPD_2IN13_V2_SendData(0x00);
+        data[0] = 0xF9;
+        data[1] = 0x00;
         EPD_2IN13_V2_SendCommand(0x4F);   // set RAM y address count to 0X127;
-        EPD_2IN13_V2_SendData(0xF9);
-        EPD_2IN13_V2_SendData(0x00);
+        EPD_2IN13_V2_SendData_nByte(&data[0], 2);
         EPD_2IN13_V2_ReadBusy();
     } else if(Mode == EPD_2IN13_V2_PART) {
         EPD_2IN13_V2_SendCommand(0x2C);     //VCOM Voltage
@@ -238,18 +255,17 @@ void EPD_2IN13_V2_Init(UBYTE Mode)
         EPD_2IN13_V2_ReadBusy();
 
         EPD_2IN13_V2_SendCommand(0x32);
-        for(count = 0; count < 70; count++) {
-            EPD_2IN13_V2_SendData(EPD_2IN13_V2_lut_partial_update[count]);
-        }
+        EPD_2IN13_V2_SendData_nByte((uint8_t*)&EPD_2IN13_V2_lut_partial_update[0], 70);
 
+        data[0] = 0x00;
+        data[1] = 0x00;
+        data[2] = 0x00;
+        data[3] = 0x00;
+        data[4] = 0x40;
+        data[5] = 0x00;
+        data[6] = 0x00;
         EPD_2IN13_V2_SendCommand(0x37);
-        EPD_2IN13_V2_SendData(0x00);
-        EPD_2IN13_V2_SendData(0x00);
-        EPD_2IN13_V2_SendData(0x00);
-        EPD_2IN13_V2_SendData(0x00);
-        EPD_2IN13_V2_SendData(0x40);
-        EPD_2IN13_V2_SendData(0x00);
-        EPD_2IN13_V2_SendData(0x00);
+        EPD_2IN13_V2_SendData_nByte(&data[0], 7);
 
         EPD_2IN13_V2_SendCommand(0x22);
         EPD_2IN13_V2_SendData(0xC0);
@@ -273,13 +289,15 @@ void EPD_2IN13_V2_Clear(void)
     UWORD Width, Height;
     Width = (EPD_2IN13_V2_WIDTH % 8 == 0)? (EPD_2IN13_V2_WIDTH / 8 ): (EPD_2IN13_V2_WIDTH / 8 + 1);
     Height = EPD_2IN13_V2_HEIGHT;
+    uint32_t len = Height * Width;
+    uint8_t data[len];
+
+    for (UWORD n = 0; n < len; n++) {
+        data[n] = 0xFF;
+    }
 
     EPD_2IN13_V2_SendCommand(0x24);
-    for (UWORD j = 0; j < Height; j++) {
-        for (UWORD i = 0; i < Width; i++) {
-            EPD_2IN13_V2_SendData(0XFF);
-        }
-    }
+    EPD_2IN13_V2_SendData_nByte(&data[0], len);
 
     EPD_2IN13_V2_TurnOnDisplay();
 }
@@ -293,13 +311,17 @@ void EPD_2IN13_V2_Display(UBYTE *Image)
     UWORD Width, Height;
     Width = (EPD_2IN13_V2_WIDTH % 8 == 0)? (EPD_2IN13_V2_WIDTH / 8 ): (EPD_2IN13_V2_WIDTH / 8 + 1);
     Height = EPD_2IN13_V2_HEIGHT;
+    uint32_t len = Height * Width;
+    uint8_t data[len];
 
-    EPD_2IN13_V2_SendCommand(0x24);
-    for (UWORD j = 0; j < Height; j++) {
+    for (UWORD j = 0, n = 0; j < Height; j++) {
         for (UWORD i = 0; i < Width; i++) {
-            EPD_2IN13_V2_SendData(Image[i + j * Width]);
+            data[n++] = Image[i + j * Width];
         }
     }
+
+    EPD_2IN13_V2_SendCommand(0x24);
+    EPD_2IN13_V2_SendData_nByte(&data[0], len);
     EPD_2IN13_V2_TurnOnDisplay();
 }
 
@@ -313,22 +335,25 @@ void EPD_2IN13_V2_DisplayPartBaseImage(UBYTE *Image)
     UWORD Width, Height;
     Width = (EPD_2IN13_V2_WIDTH % 8 == 0)? (EPD_2IN13_V2_WIDTH / 8 ): (EPD_2IN13_V2_WIDTH / 8 + 1);
     Height = EPD_2IN13_V2_HEIGHT;
+    uint32_t len = Height * Width;
+    uint8_t data24[len];
+    uint8_t data26[len];
 
-    UDOUBLE Addr = 0;
+    for (UWORD j = 0, n = 0; j < Height; j++) {
+        for (UWORD i = 0; i < Width; i++) {
+            int addr = i + j * Width;
+            data24[n] = Image[addr];
+            data26[n] = Image[addr];
+            n = n + 1;
+        }
+    }
+
     EPD_2IN13_V2_SendCommand(0x24);
-    for (UWORD j = 0; j < Height; j++) {
-        for (UWORD i = 0; i < Width; i++) {
-            Addr = i + j * Width;
-            EPD_2IN13_V2_SendData(Image[Addr]);
-        }
-    }
+    EPD_2IN13_V2_SendData_nByte(&data24[0], len);
+
     EPD_2IN13_V2_SendCommand(0x26);
-    for (UWORD j = 0; j < Height; j++) {
-        for (UWORD i = 0; i < Width; i++) {
-            Addr = i + j * Width;
-            EPD_2IN13_V2_SendData(Image[Addr]);
-        }
-    }
+    EPD_2IN13_V2_SendData_nByte(&data26[0], len);
+
     EPD_2IN13_V2_TurnOnDisplay();
 }
 
@@ -338,12 +363,17 @@ void EPD_2IN13_V2_DisplayPart(UBYTE *Image)
     UWORD Width, Height;
     Width = (EPD_2IN13_V2_WIDTH % 8 == 0)? (EPD_2IN13_V2_WIDTH / 8 ): (EPD_2IN13_V2_WIDTH / 8 + 1);
     Height = EPD_2IN13_V2_HEIGHT;
-    EPD_2IN13_V2_SendCommand(0x24);
-    for (UWORD j = 0; j < Height; j++) {
+    uint32_t len = Height * Width;
+    uint8_t data[len];
+
+    for (UWORD j = 0, n = 0; j < Height; j++) {
         for (UWORD i = 0; i < Width; i++) {
-            EPD_2IN13_V2_SendData(Image[i + j * Width]);
+            data[n++] = Image[i + j * Width];
         }
     }
+
+    EPD_2IN13_V2_SendCommand(0x24);
+    EPD_2IN13_V2_SendData_nByte(&data[0], len);
 
     EPD_2IN13_V2_TurnOnDisplayPart();
 }

--- a/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_2in13_V2.c
+++ b/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_2in13_V2.c
@@ -88,6 +88,26 @@ const unsigned char EPD_2IN13_V2_lut_partial_update[]= { //20 bytes
 
     0x15,0x41,0xA8,0x32,0x30,0x0A,
 };
+
+// EPD_2IN13_V2_WIDTH = 122
+// EPD_2IN13_V2_HEIGHT = 250
+// (122 + 1) * 250 = 30750
+#define VAL_20(X) X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X
+#define VAL_50(X) VAL_20(X), VAL_20(X), X, X, X, X, X, X, X, X, X, X
+#define VAL_100(X) VAL_20(X), VAL_20(X), VAL_20(X), VAL_20(X), VAL_20(X)
+#define VAL_200(X) VAL_100(X), VAL_100(X)
+#define VAL_500(X) VAL_100(X), VAL_100(X), VAL_100(X), VAL_100(X), VAL_100(X)
+#define VAL_2500(X) VAL_500(X), VAL_500(X), VAL_500(X), VAL_500(X), VAL_500(X)
+#define VAL_5000(X) VAL_2500(X), VAL_2500(X)
+#define VAL_12500(X) VAL_2500(X), VAL_2500(X), VAL_2500(X), VAL_2500(X), VAL_2500(X)
+#define VAL_25000(X) VAL_12500(X), VAL_12500(X)
+#define EPD_2IN13_V2_CLEAR_VAR 0xFF
+const uint8_t EPD_2IN13_V2_clear_image[] = {
+    VAL_25000(EPD_2IN13_V2_CLEAR_VAR), VAL_5000(EPD_2IN13_V2_CLEAR_VAR),
+    VAL_500(EPD_2IN13_V2_CLEAR_VAR), VAL_200(EPD_2IN13_V2_CLEAR_VAR),
+    VAL_50(EPD_2IN13_V2_CLEAR_VAR)
+};
+
 /******************************************************************************
 function :	Software reset
 parameter:
@@ -289,15 +309,9 @@ void EPD_2IN13_V2_Clear(void)
     UWORD Width, Height;
     Width = (EPD_2IN13_V2_WIDTH % 8 == 0)? (EPD_2IN13_V2_WIDTH / 8 ): (EPD_2IN13_V2_WIDTH / 8 + 1);
     Height = EPD_2IN13_V2_HEIGHT;
-    uint32_t len = Height * Width;
-    uint8_t data[len];
-
-    for (UWORD n = 0; n < len; n++) {
-        data[n] = 0xFF;
-    }
 
     EPD_2IN13_V2_SendCommand(0x24);
-    EPD_2IN13_V2_SendData_nByte(&data[0], len);
+    EPD_2IN13_V2_SendData_nByte((uint8_t*)&EPD_2IN13_V2_clear_image[0], Width * Height);
 
     EPD_2IN13_V2_TurnOnDisplay();
 }


### PR DESCRIPTION
The C libraries can be improved in a similar way to #104 and #130.

Single byte writes in loops were replaced with their multi-bytes variations.

This results in a significant performance improvement (~100% on my Pi Zero)

In addition I've replaced `printf()`s with `Debug()` and disable the debugging flag in the Makefile because libraries in production shouldn't really write to stdout/-err.