### PR TITLE
remove unused 'color' arg from Clear method

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7.py
@@ -501,7 +501,7 @@ class EPD:
         self.ReadBusy()
         # pass
         
-    def Clear(self, color):
+    def Clear(self):
         self.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
             self.send_data(0xFF)


### PR DESCRIPTION
`color` arg is unused in Clear method making this more consistent with the epd2in7b and epd2in7b_v2 screen libraries.