### PR TITLE
add color argument

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7.py
@@ -501,13 +501,13 @@ class EPD:
         self.ReadBusy()
         # pass
         
-    def Clear(self, color):
+    def Clear(self, color=0xFF):
         self.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            self.send_data(color)
         self.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0xFF)
+            self.send_data(color)
         self.send_command(0x12) 
         self.ReadBusy()
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7b.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7b.py
@@ -243,15 +243,15 @@ class EPD:
         self.send_command(0x12) 
         self.ReadBusy()
         
-    def Clear(self):
+    def Clear(self, color=0x00):
         self.send_command(0x10)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
+            self.send_data(color)
         self.send_command(0x11) 
         
         self.send_command(0x13)
         for i in range(0, int(self.width * self.height / 8)):
-            self.send_data(0x00)
+            self.send_data(color)
         self.send_command(0x11)
         
         self.send_command(0x12) 


### PR DESCRIPTION
This adds a default color argument to the 2in7 and 2in7b variety.

I don't have a 2in7b_V2 to test with, but it should be a similar modification on [ll 129](https://github.com/waveshare/e-Paper/blob/af9694c602fb24d776cd0f0b3e073a477294e3d8/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2b_V2.py#L129) and ll 130.