### PR TITLE
Pi python example of 7in5_V2: width and height reversed

### DIFF
--- a/RaspberryPi_JetsonNano/python/examples/epd_7in5_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_7in5_V2_test.py
@@ -68,7 +68,7 @@ try:
     time.sleep(2)
 
     logging.info("4.read bmp file on window")
-    Himage2 = Image.new('1', (epd.height, epd.width), 255)  # 255: clear the frame
+    Himage2 = Image.new('1', (epd.width, epd.height), 255)  # 255: clear the frame
     bmp = Image.open(os.path.join(picdir, '100x100.bmp'))
     Himage2.paste(bmp, (50,10))
     epd.display(epd.getbuffer(Himage2))


### PR DESCRIPTION
in Step 4 of 

`e-Paper/RaspberryPi_JetsonNano/python/examples/epd_7in5_V2_test.py`

`width` and `height` were reversed. I guess it was not noticed so far, because the loaded image is "small enough", such that it doesn't matter, but as soon as a bigger one is going to be loaded, the code fails.

This is a simple, one line fix to repair the reversed function parameters. 