### PR TITLE
Module-level logging

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in02.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in02.py
@@ -35,6 +35,8 @@ from . import epdconfig
 EPD_WIDTH       = 80
 EPD_HEIGHT      = 128
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -109,7 +111,7 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         self.send_command(0x71)
         busy = epdconfig.digital_read(self.busy_pin)
         busy =not(busy & 0x01)
@@ -118,7 +120,7 @@ class EPD:
             busy = epdconfig.digital_read(self.busy_pin)
             busy =not(busy & 0x01)
         epdconfig.delay_ms(800)
-        logging.debug("e-Paper busy release")        
+        logger.debug("e-Paper busy release")        
 
     def TurnOnDisplay(self):
         self.send_command(0x12)
@@ -242,14 +244,14 @@ class EPD:
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54.py
@@ -86,6 +86,8 @@ from . import epdconfig
 EPD_WIDTH       = 200
 EPD_HEIGHT      = 200
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -131,10 +133,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 1):      # 0: idle, 1: busy
             epdconfig.delay_ms(100)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
 
     def TurnOnDisplay(self):
         self.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
@@ -206,14 +208,14 @@ class EPD:
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54_V2.py
@@ -34,6 +34,8 @@ from . import epdconfig
 EPD_WIDTH       = 200
 EPD_HEIGHT      = 200
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -134,10 +136,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 1):
             epdconfig.delay_ms(20)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
 
     def TurnOnDisplay(self):
         self.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
@@ -198,7 +200,7 @@ class EPD:
             return -1
             
         if(isPartial):
-            logging.debug("partial refresh")
+            logger.debug("partial refresh")
             self.reset()
             self.ReadBusy()
             
@@ -225,7 +227,7 @@ class EPD:
             self.ReadBusy()
         
         else:
-            logging.debug("full refresh")
+            logger.debug("full refresh")
             # EPD hardware init start
             self.reset()
             
@@ -273,14 +275,14 @@ class EPD:
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54b.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54b.py
@@ -34,6 +34,8 @@ from . import epdconfig
 EPD_WIDTH       = 200
 EPD_HEIGHT      = 200
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -74,10 +76,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):
             epdconfig.delay_ms(100)    
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
       
     def set_lut_bw(self):
         self.send_command(0x20) # vcom

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54b_V2.py
@@ -34,6 +34,8 @@ from . import epdconfig
 EPD_WIDTH       = 200
 EPD_HEIGHT      = 200
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -66,10 +68,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 1):
             epdconfig.delay_ms(100)    
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
         
     def init(self):
         if (epdconfig.module_init() != 0):

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54c.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54c.py
@@ -33,6 +33,8 @@ from . import epdconfig
 EPD_WIDTH       = 152
 EPD_HEIGHT      = 152
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -64,10 +66,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      #  0: idle, 1: busy
             epdconfig.delay_ms(200)                
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
      
     def init(self):
         if (epdconfig.module_init() != 0):
@@ -101,14 +103,14 @@ class EPD:
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     #  Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y
@@ -119,11 +121,11 @@ class EPD:
 
     def display(self, blackimage, yellowimage):
         self.send_command(0x10)
-        logging.debug("blackimage")
+        logger.debug("blackimage")
         for i in range(0, int(self.width * self.height / 8)):
             self.send_data(blackimage[i])
         self.send_command(0x13)
-        logging.debug("yellowimage")
+        logger.debug("yellowimage")
         for i in range(0, int(self.width * self.height / 8)):
             self.send_data(yellowimage[i])
             

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13.py
@@ -36,6 +36,8 @@ import numpy as np
 EPD_WIDTH       = 122
 EPD_HEIGHT      = 250
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -90,9 +92,9 @@ class EPD:
         self.send_command(0x20) # MASTER_ACTIVATION
         self.send_command(0xFF) # TERMINATE_FRAME_READ_WRITE
         
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         self.ReadBusy()
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
 
     def init(self, lut):
         if (epdconfig.module_init() != 0):
@@ -168,14 +170,14 @@ class EPD:
         pixels = image_monocolor.load()
         
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):                    
                     if pixels[x, y] == 0:
                         # x = imwidth - x
                         buf[int(x / 8) + y * linewidth] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V2.py
@@ -36,6 +36,8 @@ import numpy as np
 EPD_WIDTH       = 122
 EPD_HEIGHT      = 250
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -222,14 +224,14 @@ class EPD:
         pixels = image_monocolor.load()
         
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):                    
                     if pixels[x, y] == 0:
                         x = imwidth - x
                         buf[int(x / 8) + y * linewidth] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y
@@ -293,7 +295,7 @@ class EPD:
             linewidth = int(self.width/8)
         else:
             linewidth = int(self.width/8) + 1
-        # logging.debug(linewidth)
+        # logger.debug(linewidth)
         
         self.send_command(0x24)
         for j in range(0, self.height):

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13b_V3.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13b_V3.py
@@ -34,6 +34,8 @@ from . import epdconfig
 EPD_WIDTH       = 104
 EPD_HEIGHT      = 212
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -65,12 +67,12 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         self.send_command(0x71);
         while(epdconfig.digital_read(self.busy_pin) == 0): 
             self.send_command(0x71);
             epdconfig.delay_ms(100)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
 
     def init(self):
         if (epdconfig.module_init() != 0):
@@ -96,21 +98,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13bc.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13bc.py
@@ -34,6 +34,8 @@ from . import epdconfig
 EPD_WIDTH       = 104
 EPD_HEIGHT      = 212
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -65,10 +67,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
             epdconfig.delay_ms(100)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
 
     def init(self):
         if (epdconfig.module_init() != 0):
@@ -97,21 +99,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13d.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13d.py
@@ -37,6 +37,8 @@ import RPi.GPIO as GPIO
 EPD_WIDTH       = 104
 EPD_HEIGHT      = 212
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -170,11 +172,11 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
             self.send_command(0x71)
             epdconfig.delay_ms(100)  
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
         
     def TurnOnDisplay(self):
         self.send_command(0x12)
@@ -263,21 +265,21 @@ class EPD:
             self.send_data(self.lut_bb1[count])
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in66.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in66.py
@@ -34,6 +34,8 @@ from . import epdconfig
 EPD_WIDTH       = 152
 EPD_HEIGHT      = 296
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -88,10 +90,10 @@ class EPD:
 
 
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 1):      #  0: idle, 1: busy
             epdconfig.delay_ms(200) 
-        logging.debug("e-Paper busy release") 
+        logger.debug("e-Paper busy release") 
 
 
     def init(self, mode):
@@ -143,7 +145,7 @@ class EPD:
             self.ReadBusy()
 
         else:
-            logging.debug("There is no such mode") 
+            logger.debug("There is no such mode") 
 
         return 0
 
@@ -159,21 +161,21 @@ class EPD:
         self.ReadBusy()
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in66b.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in66b.py
@@ -34,6 +34,8 @@ from . import epdconfig
 EPD_WIDTH       = 152
 EPD_HEIGHT      = 296
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -68,10 +70,10 @@ class EPD:
 
 
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 1):      #  0: idle, 1: busy
             epdconfig.delay_ms(20) 
-        logging.debug("e-Paper busy release") 
+        logger.debug("e-Paper busy release") 
 
 
     def init(self):
@@ -122,21 +124,21 @@ class EPD:
         self.ReadBusy()
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7.py
@@ -38,6 +38,9 @@ GRAY1  = 0xff #white
 GRAY2  = 0xC0
 GRAY3  = 0x80 #gray
 GRAY4  = 0x00 #Blackest
+
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -171,10 +174,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):        
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      #  0: idle, 1: busy
             epdconfig.delay_ms(200)                
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
 
     def set_lut(self):
         self.send_command(0x20) # vcom
@@ -361,21 +364,21 @@ class EPD:
         self.send_data(0x57)
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y
@@ -385,15 +388,15 @@ class EPD:
         return buf
     
     def getbuffer_4Gray(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width / 4) * self.height)
         image_monocolor = image.convert('L')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
         i=0
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
@@ -406,7 +409,7 @@ class EPD:
                         buf[int((x + (y * self.width))/4)] = ((pixels[x-3, y]&0xc0) | (pixels[x-2, y]&0xc0)>>2 | (pixels[x-1, y]&0xc0)>>4 | (pixels[x, y]&0xc0)>>6)
                         
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for x in range(imwidth):
                 for y in range(imheight):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7b.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7b.py
@@ -35,6 +35,8 @@ from . import epdconfig
 EPD_WIDTH       = 176
 EPD_HEIGHT      = 264
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -119,10 +121,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
             epdconfig.delay_ms(100)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
         
     def set_lut(self):
         self.send_command(0x20)               # vcom
@@ -206,21 +208,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7b_V2.py
@@ -35,6 +35,8 @@ from . import epdconfig
 EPD_WIDTH       = 176
 EPD_HEIGHT      = 264
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -69,10 +71,10 @@ class EPD:
         
     # Read Busy
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 1):      # 0: idle, 1: busy
             epdconfig.delay_ms(10)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
             
     # Setting the display window
     def SetWindows(self, Xstart, Ystart, Xend, Yend):
@@ -118,21 +120,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9.py
@@ -34,6 +34,8 @@ from . import epdconfig
 EPD_WIDTH       = 128
 EPD_HEIGHT      = 296
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -90,9 +92,9 @@ class EPD:
         self.send_command(0x20) # MASTER_ACTIVATION
         self.send_command(0xFF) # TERMINATE_FRAME_READ_WRITE
         
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         self.ReadBusy()
-        logging.debug("e-Paper busy release")  
+        logger.debug("e-Paper busy release")  
 
     def SetWindow(self, x_start, y_start, x_end, y_end):
         self.send_command(0x44) # SET_RAM_X_ADDRESS_START_END_POSITION
@@ -149,21 +151,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9_V2.py
@@ -34,6 +34,8 @@ from . import epdconfig
 EPD_WIDTH       = 128
 EPD_HEIGHT      = 296
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -109,10 +111,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 1):      #  0: idle, 1: busy
             epdconfig.delay_ms(10) 
-        logging.debug("e-Paper busy release")  
+        logger.debug("e-Paper busy release")  
 
     def TurnOnDisplay(self):
         self.send_command(0x22) # DISPLAY_UPDATE_CONTROL_2
@@ -197,21 +199,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9b_V3.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9b_V3.py
@@ -35,6 +35,8 @@ from . import epdconfig
 EPD_WIDTH       = 128
 EPD_HEIGHT      = 296
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -66,12 +68,12 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         self.send_command(0X71)
         while(epdconfig.digital_read(self.busy_pin) == 0):      #  0: idle, 1: busy
             self.send_command(0X71)
             epdconfig.delay_ms(200)                
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
         
     def init(self):
         if (epdconfig.module_init() != 0):
@@ -98,21 +100,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9bc.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9bc.py
@@ -35,6 +35,8 @@ from . import epdconfig
 EPD_WIDTH       = 128
 EPD_HEIGHT      = 296
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -66,10 +68,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      #  0: idle, 1: busy
             epdconfig.delay_ms(200)                
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
         
     def init(self):
         if (epdconfig.module_init() != 0):
@@ -97,21 +99,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9d.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9d.py
@@ -39,6 +39,8 @@ import RPi.GPIO as GPIO
 EPD_WIDTH       = 128
 EPD_HEIGHT      = 296
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -129,11 +131,11 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
             self.send_command(0x71)
             epdconfig.delay_ms(10)  
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
         
     def TurnOnDisplay(self):
         self.send_command(0x12)
@@ -213,21 +215,21 @@ class EPD:
             self.send_data(self.lut_bb1[count])
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in7.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in7.py
@@ -36,8 +36,11 @@ EPD_HEIGHT      = 480
 
 GRAY1  = 0xff #white
 GRAY2  = 0xC0 #Close to white
-GRAY3  = 0x80 #Close to balck
-GRAY4  = 0x00 #balck
+GRAY3  = 0x80 #Close to black
+GRAY4  = 0x00 #black
+
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -132,10 +135,10 @@ class EPD:
 
 
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 1):      #  0: idle, 1: busy
             epdconfig.delay_ms(10) 
-        logging.debug("e-Paper busy release") 
+        logger.debug("e-Paper busy release") 
 
 
     def init(self, mode):
@@ -211,7 +214,7 @@ class EPD:
             self.send_data(0xFF)
             self.send_data(0xFF)
         else:
-            logging.debug("There is no such mode") 
+            logger.debug("There is no such mode") 
 
         self.send_command(0x44) # setting X direction start/end position of RAM
         self.send_data(0x00)
@@ -237,21 +240,21 @@ class EPD:
 
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y
@@ -262,15 +265,15 @@ class EPD:
 
 
     def getbuffer_4Gray(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width / 4) * self.height)
         image_monocolor = image.convert('L')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
         i=0
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
@@ -283,7 +286,7 @@ class EPD:
                         buf[int((x + (y * self.width))/4)] = ((pixels[x-3, y]&0xc0) | (pixels[x-2, y]&0xc0)>>2 | (pixels[x-1, y]&0xc0)>>4 | (pixels[x, y]&0xc0)>>6)
                         
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for x in range(imwidth):
                 for y in range(imheight):
                     newx = y
@@ -430,7 +433,7 @@ class EPD:
         elif(mode == 1):            #1Gray
             self.load_lut(self.lut_1Gray_DU)
         else:
-            logging.debug("There is no such mode") 
+            logger.debug("There is no such mode") 
 
         self.send_command(0x20)
         self.ReadBusy()   

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in01f.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in01f.py
@@ -36,6 +36,8 @@ from . import epdconfig
 EPD_WIDTH       = 640
 EPD_HEIGHT      = 400
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -75,16 +77,16 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusyHigh(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
             epdconfig.delay_ms(10)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
         
     def ReadBusyLow(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 1):      # 0: idle, 1: busy
             epdconfig.delay_ms(10)    
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
         
     def init(self):
         if (epdconfig.module_init() != 0):
@@ -129,7 +131,7 @@ class EPD:
         image_monocolor = image.convert('RGB')#Picture mode conversion
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        logging.debug('imwidth = %d  imheight =  %d ',imwidth, imheight)
+        logger.debug('imwidth = %d  imheight =  %d ',imwidth, imheight)
         if(imwidth == self.width and imheight == self.height):
             for y in range(imheight):
                 for x in range(imwidth):

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2.py
@@ -42,6 +42,8 @@ GRAY2  = 0xC0
 GRAY3  = 0x80 #gray
 GRAY4  = 0x00 #Blackest
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -388,21 +390,21 @@ class EPD:
         self.send_data(0x97)
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y
@@ -412,15 +414,15 @@ class EPD:
         return buf
         
     def getbuffer_4Gray(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width / 4) * self.height)
         image_monocolor = image.convert('L')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
         i=0
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
@@ -433,7 +435,7 @@ class EPD:
                         buf[int((x + (y * self.width))/4)] = ((pixels[x-3, y]&0xc0) | (pixels[x-2, y]&0xc0)>>2 | (pixels[x-1, y]&0xc0)>>4 | (pixels[x, y]&0xc0)>>6)
                         
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for x in range(imwidth):
                 for y in range(imheight):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2b_V2.py
@@ -34,6 +34,8 @@ from . import epdconfig
 EPD_WIDTH       = 400
 EPD_HEIGHT      = 300
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -65,12 +67,12 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         self.send_command(0x71);
         while(epdconfig.digital_read(self.busy_pin) == 0): # 0: idle, 1: busy
             self.send_command(0x71);
             epdconfig.delay_ms(20)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
             
     def init(self):
         if (epdconfig.module_init() != 0):
@@ -87,21 +89,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2bc.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2bc.py
@@ -34,6 +34,8 @@ from . import epdconfig
 EPD_WIDTH       = 400
 EPD_HEIGHT      = 300
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -65,10 +67,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0): # 0: idle, 1: busy
             epdconfig.delay_ms(100)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
             
     def init(self):
         if (epdconfig.module_init() != 0):
@@ -90,21 +92,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in65f.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in65f.py
@@ -40,6 +40,8 @@ import io
 EPD_WIDTH       = 600
 EPD_HEIGHT      = 448
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -85,16 +87,16 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
 
     def ReadBusyHigh(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
             epdconfig.delay_ms(100)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
 
     def ReadBusyLow(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 1):      # 0: idle, 1: busy
             epdconfig.delay_ms(100)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
 
     def init(self):
         if (epdconfig.module_init() != 0):
@@ -151,7 +153,7 @@ class EPD:
         elif(imwidth == self.height and imheight == self.width):
             image_temp = image.rotate(90, expand=True)
         else:
-            logging.warning("Invalid image dimensions: %d x %d, expected %d x %d" % (imwidth, imheight, self.width, self.height))
+            logger.warning("Invalid image dimensions: %d x %d, expected %d x %d" % (imwidth, imheight, self.width, self.height))
 
         # Convert the soruce image to the 7 colors, dithering if needed
         image_7color = image_temp.convert("RGB").quantize(palette=pal_image)

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83.py
@@ -35,6 +35,8 @@ from . import epdconfig
 EPD_WIDTH       = 600
 EPD_HEIGHT      = 448
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -66,10 +68,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
             epdconfig.delay_ms(100)    
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
         
     def init(self):
         if (epdconfig.module_init() != 0):
@@ -125,7 +127,7 @@ class EPD:
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        logging.debug('imwidth = %d  imheight =  %d ',imwidth, imheight)
+        logger.debug('imwidth = %d  imheight =  %d ',imwidth, imheight)
         if(imwidth == self.width and imheight == self.height):
             for y in range(imheight):
                 for x in range(imwidth):

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83_V2.py
@@ -34,6 +34,8 @@ from . import epdconfig
 EPD_WIDTH       = 648
 EPD_HEIGHT      = 480
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -65,10 +67,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      
             epdconfig.delay_ms(20)    
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
         
     def TurnOnDisplay(self):
         self.send_command(0x12);    #POWER ON
@@ -114,21 +116,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83b_V2.py
@@ -35,6 +35,8 @@ from . import epdconfig
 EPD_WIDTH       = 648
 EPD_HEIGHT      = 480
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -66,12 +68,12 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         self.send_command(0X71)
         while(epdconfig.digital_read(self.busy_pin) == 0):      #  0: idle, 1: busy
             self.send_command(0X71)
             epdconfig.delay_ms(200)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
             
     def init(self):
         if (epdconfig.module_init() != 0):
@@ -111,21 +113,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        # logging.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83bc.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83bc.py
@@ -35,6 +35,8 @@ from . import epdconfig
 EPD_WIDTH       = 600
 EPD_HEIGHT      = 448
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -66,10 +68,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
             epdconfig.delay_ms(100)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
             
     def init(self):
         if (epdconfig.module_init() != 0):
@@ -117,21 +119,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        logging.debug('imwidth = %d  imheight =  %d ',imwidth, imheight)
+        logger.debug('imwidth = %d  imheight =  %d ',imwidth, imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5.py
@@ -35,6 +35,8 @@ from . import epdconfig
 EPD_WIDTH       = 640
 EPD_HEIGHT      = 384
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -72,10 +74,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
             epdconfig.delay_ms(100)    
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
         
     def init(self):
         if (epdconfig.module_init() != 0):
@@ -134,7 +136,7 @@ class EPD:
             img = img.rotate(90, expand=True).convert('1')
             imwidth, imheight = img.size
         else:
-            logging.warning("Wrong image dimensions: must be " + str(self.width) + "x" + str(self.height))
+            logger.warning("Wrong image dimensions: must be " + str(self.width) + "x" + str(self.height))
             # return a blank buffer
             return buf
         

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_HD.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_HD.py
@@ -35,6 +35,8 @@ from . import epdconfig
 EPD_WIDTH       = 880
 EPD_HEIGHT      = 528
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -72,7 +74,7 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         busy = epdconfig.digital_read(self.busy_pin)
         while(busy == 1):
             busy = epdconfig.digital_read(self.busy_pin)
@@ -136,7 +138,7 @@ class EPD:
         elif(imwidth == self.height and imheight == self.width):
             img = img.rotate(90, expand=True).convert('1')
         else:
-            logging.warning("Wrong image dimensions: must be " + str(self.width) + "x" + str(self.height))
+            logger.warning("Wrong image dimensions: must be " + str(self.width) + "x" + str(self.height))
             # return a blank buffer
             return [0xff] * int(self.width * self.height / 8)
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
@@ -35,6 +35,8 @@ from . import epdconfig
 EPD_WIDTH       = 800
 EPD_HEIGHT      = 480
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -126,14 +128,14 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
 
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         self.send_command(0x71)
         busy = epdconfig.digital_read(self.busy_pin)
         while(busy == 0):
             self.send_command(0x71)
             busy = epdconfig.digital_read(self.busy_pin)
         epdconfig.delay_ms(20)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
         
     def SetLut(self, lut_vcom, lut_ww, lut_bw, lut_wb, lut_bb):
         self.send_command(0x20)
@@ -235,7 +237,7 @@ class EPD:
             # image has correct dimensions, but needs to be rotated
             img = img.rotate(90, expand=True).convert('1')
         else:
-            logging.warning("Wrong image dimensions: must be " + str(self.width) + "x" + str(self.height))
+            logger.warning("Wrong image dimensions: must be " + str(self.width) + "x" + str(self.height))
             # return a blank buffer
             return [0x00] * (int(self.width/8) * self.height)
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5b_HD.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5b_HD.py
@@ -35,6 +35,8 @@ from . import epdconfig
 EPD_WIDTH       = 880
 EPD_HEIGHT      = 528
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -66,7 +68,7 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         busy = epdconfig.digital_read(self.busy_pin)
         while(busy == 1):
             busy = epdconfig.digital_read(self.busy_pin)
@@ -135,21 +137,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        logging.debug('imwidth = %d  imheight =  %d ',imwidth, imheight)
+        logger.debug('imwidth = %d  imheight =  %d ',imwidth, imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5b_V2.py
@@ -35,6 +35,8 @@ from . import epdconfig
 EPD_WIDTH       = 800
 EPD_HEIGHT      = 480
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -66,14 +68,14 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         self.send_command(0x71)
         busy = epdconfig.digital_read(self.busy_pin)
         while(busy == 0):
             self.send_command(0x71)
             busy = epdconfig.digital_read(self.busy_pin)
         epdconfig.delay_ms(200)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
         
     def init(self):
         if (epdconfig.module_init() != 0):
@@ -125,21 +127,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        logging.debug('imwidth = %d  imheight =  %d ',imwidth, imheight)
+        logger.debug('imwidth = %d  imheight =  %d ',imwidth, imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5bc.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5bc.py
@@ -35,6 +35,8 @@ from . import epdconfig
 EPD_WIDTH       = 640
 EPD_HEIGHT      = 384
 
+logger = logging.getLogger(__name__)
+
 class EPD:
     def __init__(self):
         self.reset_pin = epdconfig.RST_PIN
@@ -66,10 +68,10 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
         
     def ReadBusy(self):
-        logging.debug("e-Paper busy")
+        logger.debug("e-Paper busy")
         while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
             epdconfig.delay_ms(100)
-        logging.debug("e-Paper busy release")
+        logger.debug("e-Paper busy release")
             
     def init(self):
         if (epdconfig.module_init() != 0):
@@ -117,21 +119,21 @@ class EPD:
         return 0
 
     def getbuffer(self, image):
-        # logging.debug("bufsiz = ",int(self.width/8) * self.height)
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
         buf = [0xFF] * (int(self.width/8) * self.height)
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         pixels = image_monocolor.load()
-        logging.debug('imwidth = %d  imheight =  %d ',imwidth, imheight)
+        logger.debug('imwidth = %d  imheight =  %d ',imwidth, imheight)
         if(imwidth == self.width and imheight == self.height):
-            logging.debug("Horizontal")
+            logger.debug("Horizontal")
             for y in range(imheight):
                 for x in range(imwidth):
                     # Set the bits for the column of pixels at the current position.
                     if pixels[x, y] == 0:
                         buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         elif(imwidth == self.height and imheight == self.width):
-            logging.debug("Vertical")
+            logger.debug("Vertical")
             for y in range(imheight):
                 for x in range(imwidth):
                     newx = y

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -32,6 +32,8 @@ import logging
 import sys
 import time
 
+logger = logging.getLogger(__name__)
+
 
 class RaspberryPi:
     # Pin definition
@@ -77,10 +79,10 @@ class RaspberryPi:
         return 0
 
     def module_exit(self):
-        logging.debug("spi end")
+        logger.debug("spi end")
         self.SPI.close()
 
-        logging.debug("close 5V, Module enters 0 power consumption ...")
+        logger.debug("close 5V, Module enters 0 power consumption ...")
         self.GPIO.output(self.RST_PIN, 0)
         self.GPIO.output(self.DC_PIN, 0)
 
@@ -136,10 +138,10 @@ class JetsonNano:
         return 0
 
     def module_exit(self):
-        logging.debug("spi end")
+        logger.debug("spi end")
         self.SPI.SYSFS_software_spi_end()
 
-        logging.debug("close 5V, Module enters 0 power consumption ...")
+        logger.debug("close 5V, Module enters 0 power consumption ...")
         self.GPIO.output(self.RST_PIN, 0)
         self.GPIO.output(self.DC_PIN, 0)
 


### PR DESCRIPTION
This makes it easier to distinguish between log entries from different sources.

For example, here's the output of epd_7in5_V2_test.py, which logs messages from itself, epd7in5_V2.py, and epdconfig.py

Before:
```console
pi@pizero:~/examples $ python3 epd_7in5_V2_test.py
INFO:root:epd7in5_V2 Demo
INFO:root:init and Clear
DEBUG:root:e-Paper busy
DEBUG:root:e-Paper busy release
DEBUG:root:e-Paper busy
DEBUG:root:e-Paper busy release
INFO:root:1.Drawing on the Horizontal image...
DEBUG:root:e-Paper busy
DEBUG:root:e-Paper busy release
INFO:root:2.Drawing on the Vertical image...
DEBUG:root:e-Paper busy
DEBUG:root:e-Paper busy release
INFO:root:3.read bmp file
DEBUG:root:e-Paper busy
DEBUG:root:e-Paper busy release
INFO:root:4.read bmp file on window
DEBUG:root:e-Paper busy
DEBUG:root:e-Paper busy release
INFO:root:Clear...
DEBUG:root:e-Paper busy
DEBUG:root:e-Paper busy release
DEBUG:root:e-Paper busy
DEBUG:root:e-Paper busy release
INFO:root:Goto Sleep...
DEBUG:root:e-Paper busy
DEBUG:root:e-Paper busy release
DEBUG:root:spi end
DEBUG:root:close 5V, Module enters 0 power consumption ...
```

After:
```console
pi@pizero:~/examples $ python3 epd_7in5_V2_test.py
INFO:root:epd7in5_V2 Demo
INFO:root:init and Clear
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy release
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy release
INFO:root:1.Drawing on the Horizontal image...
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy release
INFO:root:2.Drawing on the Vertical image...
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy release
INFO:root:3.read bmp file
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy release
INFO:root:4.read bmp file on window
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy release
INFO:root:Clear...
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy release
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy release
INFO:root:Goto Sleep...
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy
DEBUG:waveshare_epd.epd7in5_V2:e-Paper busy release
DEBUG:waveshare_epd.epdconfig:spi end
DEBUG:waveshare_epd.epdconfig:close 5V, Module enters 0 power consumption ...
```