### PR TITLE
Fix for 3.7in resolution

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in7.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in7.py
@@ -31,8 +31,8 @@ import logging
 from . import epdconfig
 
 # Display resolution
-EPD_WIDTH       = 280
-EPD_HEIGHT      = 480
+EPD_WIDTH       = 480
+EPD_HEIGHT      = 280
 
 GRAY1  = 0xff #white
 GRAY2  = 0xC0 #Close to white


### PR DESCRIPTION
In the Python library the height and width values for the 3.7in EPD appear to be backwards. The [description of the device](https://www.waveshare.com/3.7inch-e-Paper-HAT.htm) on the Waveshare page lists it's resolution as 480x280. This would be 480 in width by 280 in height. Current files have these values swapped. This swaps the values so the correct width and height are returned when referencing them for EPD dimensions. 