### PR TITLE
remove GPIO.cleanup from module_exit() function

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -86,9 +86,6 @@ class RaspberryPi:
         self.GPIO.output(self.RST_PIN, 0)
         self.GPIO.output(self.DC_PIN, 0)
 
-        self.GPIO.cleanup()
-
-
 class JetsonNano:
     # Pin definition
     RST_PIN         = 17


### PR DESCRIPTION
This general `GPIO.cleanup()` is executed every time we put the display to sleep but we probably want to keep using those already initialized GPIOs.

e.g. if you used functions like `GPIO.add_event_detect()` and put the display into sleep mode, the configured events stop working.
This can cause issues like this one: https://github.com/llvllch/btcticker/pull/76

Please consider to either merge this PR or to move the `GPIO.cleanup()` to some other place.