### PR TITLE
e-paper busy endless loop work-around for epd7in5_V2.py

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
@@ -128,7 +128,7 @@ class EPD:
         epdconfig.digital_write(self.cs_pin, 1)
 
     def ReadBusy(self):
-        logger.debug("e-Paper busy")
+	logger.debug("e-Paper busy")
 	# self.send_command(0x71)
 	iter = 0
         while epdconfig.digital_read(self.busy_pin) == 0:

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
@@ -129,15 +129,15 @@ class EPD:
 
     def ReadBusy(self):
         logger.debug("e-Paper busy")
-        # self.send_command(0x71)
+	# self.send_command(0x71)
 	iter = 0
         while epdconfig.digital_read(self.busy_pin) == 0:
-            # self.send_command(0x71)
-	    epdconfig.delay_ms(100)
-            iter += 1
-	    if iter > 150:
-                logger.info("Forced e-paper busy release")
-		break
+		# self.send_command(0x71)
+		epdconfig.delay_ms(100)
+		iter += 1
+		if iter > 150:
+			logger.info("Forced e-paper busy release")
+			break
         logger.debug("e-Paper busy release")
         
     def SetLut(self, lut_vcom, lut_ww, lut_bw, lut_wb, lut_bb):

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
@@ -134,7 +134,7 @@ class EPD:
         while epdconfig.digital_read(self.busy_pin) == 0:
             # self.send_command(0x71)
 	    epdconfig.delay_ms(100)
-            iter += 1
+            count += 1
 	    if count > 150:
                 logger.info("Forced e-paper busy release")
 		break

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
@@ -130,12 +130,12 @@ class EPD:
     def ReadBusy(self):
         logger.debug("e-Paper busy")
         # self.send_command(0x71)
-	count = 0
+	iter = 0
         while epdconfig.digital_read(self.busy_pin) == 0:
             # self.send_command(0x71)
 	    epdconfig.delay_ms(100)
-            count += 1
-	    if count > 150:
+            iter += 1
+	    if iter > 150:
                 logger.info("Forced e-paper busy release")
 		break
         logger.debug("e-Paper busy release")

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
@@ -129,12 +129,15 @@ class EPD:
 
     def ReadBusy(self):
         logger.debug("e-Paper busy")
-        self.send_command(0x71)
-        busy = epdconfig.digital_read(self.busy_pin)
-        while(busy == 0):
-            self.send_command(0x71)
-            busy = epdconfig.digital_read(self.busy_pin)
-        epdconfig.delay_ms(20)
+        # self.send_command(0x71)
+	count = 0
+        while epdconfig.digital_read(self.busy_pin) == 0:
+            # self.send_command(0x71)
+	    epdconfig.delay_ms(100)
+            iter += 1
+	    if count > 150:
+                logger.info("Forced e-paper busy release")
+		break
         logger.debug("e-Paper busy release")
         
     def SetLut(self, lut_vcom, lut_ww, lut_bw, lut_wb, lut_bb):

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
@@ -203,7 +203,7 @@ class EPD:
         self.ReadBusy()
 
         self.send_command(0X00)			#PANNEL SETTING
-        self.send_data(0x3F)   #KW-3f   KWR-2F	BWROTP 0f	BWOTP 1f
+        self.send_data(0x1F)   #KW-3f   KWR-2F	BWROTP 0f	BWOTP 1f
 
         self.send_command(0x61)        	#tres
         self.send_data(0x03)		#source 800

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
@@ -203,7 +203,7 @@ class EPD:
         self.ReadBusy()
 
         self.send_command(0X00)			#PANNEL SETTING
-        self.send_data(0x1F)   #KW-3f   KWR-2F	BWROTP 0f	BWOTP 1f
+        self.send_data(0x3F)   #KW-3f   KWR-2F	BWROTP 0f	BWOTP 1f
 
         self.send_command(0x61)        	#tres
         self.send_data(0x03)		#source 800

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
@@ -131,7 +131,7 @@ class EPD:
 	logger.debug("e-Paper busy")
 	# self.send_command(0x71)
 	iter = 0
-        while epdconfig.digital_read(self.busy_pin) == 0:
+	while epdconfig.digital_read(self.busy_pin) == 0:
 		# self.send_command(0x71)
 		epdconfig.delay_ms(100)
 		iter += 1


### PR DESCRIPTION
This updates epd7in5_V2.py to create a break in the ReadBusy loop if it becomes endless. I have had problems with it entering the while loop and never exiting on my Pi Zero W. With this change, it breaks the loop and allows the program to keep running instead of freezing. I have had the loop become endless relatively frequently on the Pi0W and much less often on a Pi 3 and a Pi 4b. This change is taken from the work of others trying to solve issue https://github.com/waveshare/e-Paper/issues/30