### PR TITLE
add return code to init function

### DIFF
--- a/Arduino/epd4in01f/epd4in01f.cpp
+++ b/Arduino/epd4in01f/epd4in01f.cpp
@@ -82,6 +82,7 @@ int Epd::Init(void) {
 	SendData(0x90);
 	SendCommand(0xE3);
 	SendData(0xAA);
+	return 0;
 }
 
 /**


### PR DESCRIPTION
the function did not have a default return and would result in the init to seemingly fail and the setup function would just end then and there and never draw anythign on the display. 