### PR TITLE
Fixed ClearFrame and WaitUntilIdle on 4.2in EPD

### DIFF
--- a/Arduino/epd4in2/epd4in2.cpp
+++ b/Arduino/epd4in2/epd4in2.cpp
@@ -132,10 +132,8 @@ void Epd::SendData(unsigned char data) {
  *  @brief: Wait until the busy_pin goes HIGH
  */
 void Epd::WaitUntilIdle(void) {
-	SendCommand(0x71);
     while(DigitalRead(busy_pin) == 0) {      //0: busy, 1: idle
-        DelayMs(100);
-		SendCommand(0x71);
+        // Wait
     }      
 }
 
@@ -418,10 +416,6 @@ void Epd::ClearFrame(void) {
         SendData(0xFF);  
     }  
     DelayMs(2);
-	SetLut();
-	SendCommand(DISPLAY_REFRESH); 
-    DelayMs(100);
-    WaitUntilIdle();
 }
 
 /**


### PR DESCRIPTION
ClearFrame was refreshing the display despite the comment claiming it won't, and WaitUntilIdle was sending unnecessary SPI commands with an unnecessary delay of 100ms.

ClearFrame now only clears SRAM as intended and WaitUntilIdle is sped up significantly.