### PR TITLE
only cleanup the GPIOs in use instead of all GPIOs (Python)

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -145,7 +145,7 @@ class JetsonNano:
         self.GPIO.output(self.RST_PIN, 0)
         self.GPIO.output(self.DC_PIN, 0)
 
-        self.GPIO.cleanup()
+        self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN])
 
 
 if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835'):

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -86,7 +86,7 @@ class RaspberryPi:
         self.GPIO.output(self.RST_PIN, 0)
         self.GPIO.output(self.DC_PIN, 0)
 
-        self.GPIO.cleanup()
+        self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN])
 
 
 class JetsonNano:


### PR DESCRIPTION
`GPIO.cleanup()` causes that buttons/LEDs/etc. connected to other GPIOs stop working after writing to the epd