### PR TITLE
Fixed EPD_4in2b_V2 not working on raspberry pi b+ v1.2

### DIFF
--- a/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_4in2b_V2.c
+++ b/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_4in2b_V2.c
@@ -40,7 +40,7 @@ static void EPD_4IN2B_V2_Reset(void)
     DEV_Digital_Write(EPD_RST_PIN, 1);
     DEV_Delay_ms(200);
     DEV_Digital_Write(EPD_RST_PIN, 0);
-    DEV_Delay_ms(2);
+    DEV_Delay_ms(5);
     DEV_Digital_Write(EPD_RST_PIN, 1);
     DEV_Delay_ms(200);
 }


### PR DESCRIPTION
I am not sure how this fixes it but on raspberry pi b+ v1.2 EPD_4in2b_V2 c version wasn't working for me while python version does. I started comparing the code and noticed that python has 5ms delay here and when I changed C version to 5ms as well it started working

In C version drawing/clearing was all glitchy. For example clear function was just trying to clear part of the screen I think