### PR TITLE
Use spidev for Jetson devices

### DIFF
--- a/RaspberryPi_JetsonNano/python/setup.py
+++ b/RaspberryPi_JetsonNano/python/setup.py
@@ -1,10 +1,10 @@
 import sys, os
 from setuptools import setup
 
-dependencies = ['Pillow']
+dependencies = ['Pillow', 'spidev']
 
 if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835'):
-    dependencies += ['RPi.GPIO', 'spidev']
+    dependencies += ['RPi.GPIO']
 else:
     dependencies += ['Jetson.GPIO']
 


### PR DESCRIPTION
The Jetson modules support SPI on the GPIO Headers.

To enable SPI, you need to follow the steps on https://elinux.org/Jetson/TX2_SPI or https://jetsonhacks.com/2020/05/04/spi-on-jetson-using-jetson-io/

Then, you can use the display without any static or distorted images.