### PR TITLE
Remove second display initialization

### DIFF
--- a/Arduino/epd2in9_V2/epd2in9_V2.ino
+++ b/Arduino/epd2in9_V2/epd2in9_V2.ino
@@ -92,11 +92,6 @@ void setup() {
 
   delay(2000);
 
-  if (epd.Init() != 0) {
-      Serial.print("e-Paper init failed ");
-      return;
-  }
-
   /** 
    *  there are 2 memory areas embedded in the e-paper display
    *  and once the display is refreshed, the memory area will be auto-toggled,


### PR DESCRIPTION
Calling the init method a second time hangs forever, so the loop is never executed otherwise. Removing the second call fixes it.