### PR TITLE
remove unused linewidth code

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V3.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V3.py
@@ -309,11 +309,6 @@ class EPD:
         image : Image data
     '''
     def displayPartial(self, image):
-        if self.width%8 == 0:
-            linewidth = int(self.width/8)
-        else:
-            linewidth = int(self.width/8) + 1
-
         epdconfig.digital_write(self.reset_pin, 0)
         epdconfig.delay_ms(1)
         epdconfig.digital_write(self.reset_pin, 1)  
@@ -355,11 +350,6 @@ class EPD:
         image : Image data
     '''
     def displayPartBaseImage(self, image):
-        if self.width%8 == 0:
-            linewidth = int(self.width/8)
-        else:
-            linewidth = int(self.width/8) + 1
-
         self.send_command(0x24)
         self.send_data2(image)  
                 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13b_V4.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13b_V4.py
@@ -163,11 +163,6 @@ class EPD:
 
     # display image
     def display(self, imageblack, imagered):
-        if self.width%8 == 0:
-            linewidth = int(self.width/8)
-        else:
-            linewidth = int(self.width/8) + 1
-    
         self.send_command(0x24)
         self.send_data2(imageblack)
         


### PR DESCRIPTION
There was some leftover linewidth computation code for the 2in13 displays, this PR removes it.