### PR TITLE
Update default value for 'color' in the Clear() for the 2in13 (bw screen) libraries

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13.py
@@ -201,7 +201,7 @@ class EPD:
                 self.send_data(image[i + j * linewidth])   
         self.TurnOnDisplay()
     
-    def Clear(self, color):
+    def Clear(self, color=0xFF):
         if self.width%8 == 0:
             linewidth = int(self.width/8)
         else:

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V2.py
@@ -280,7 +280,7 @@ class EPD:
         self.send_data2(image)  
         self.TurnOnDisplay()
     
-    def Clear(self, color):
+    def Clear(self, color=0xFF):
         if self.width%8 == 0:
             linewidth = int(self.width/8)
         else:

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V3.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V3.py
@@ -361,7 +361,7 @@ class EPD:
     function : Clear screen
     parameter:
     '''
-    def Clear(self, color):
+    def Clear(self, color=0xFF):
         if self.width%8 == 0:
             linewidth = int(self.width/8)
         else:


### PR DESCRIPTION
This will allow the screen to be cleared without the `color` parameter being explicitly included (similar to the 2in7 library)